### PR TITLE
Fixed Associate Tags call URL

### DIFF
--- a/public Admin APIs.postman_collection.json
+++ b/public Admin APIs.postman_collection.json
@@ -2253,7 +2253,7 @@
 					"raw": "[\"tagA,\" \"tagB\"]"
 				},
 				"url": {
-					"raw": "{{base-url}}/internal/api/v2/tags/ws/{{workspace-id}}/<split_name>/object/<object_name>/objecttype/<object_type>",
+					"raw": "{{base-url}}/internal/api/v2/tags/ws/{{workspace-id}}/object/<object_name>/objecttype/<object_type>",
 					"host": [
 						"{{base-url}}"
 					],


### PR DESCRIPTION
Remove "split name" from Associate Tags call URL