### PR TITLE
Feature/Clean prod Environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Currently, this is a community maintained repo. Feel free to contribute any miss
  * Clone this repository
  * Import collection by importing the file `public Admin APIs.postman_collection.json`
  * Import environments by importing the file `prod.postman_environment.json`
- * In the environments tab, fill in the content of `auth-token` in the "current" column with your admin api key (https://docs.split.io/reference#authentication)
+ * In the environments tab, fill in the content of `apikey-auth` in the "current" column with your admin api key (https://docs.split.io/reference/authentication)
  * Hit any endpoint!
 
 # Contribute

--- a/prod.postman_environment.json
+++ b/prod.postman_environment.json
@@ -1,14 +1,35 @@
 {
-	"id": "3872d566-4681-49e1-a020-2724b53ff528",
+	"id": "46f9254f-55ee-4f4c-92d5-b0c9cee447c7",
 	"name": "prod",
 	"values": [
 		{
-			"key": "auth-token",
+			"key": "apikey-auth",
 			"value": "<Replace Admin API Key>",
+			"type": "secret",
+			"enabled": true
+		},
+		{
+			"key": "org-id",
+			"value": "<Replace Org ID>",
+			"enabled": true
+		},
+		{
+			"key": "workspace-id",
+			"value": "<Replace Workspace ID>",
+			"enabled": true
+		},
+		{
+			"key": "environment-id",
+			"value": "<Replace Environment ID>",
+			"enabled": true
+		},
+		{
+			"key": "traffictype-id",
+			"value": "<Replace Traffic Type ID>",
 			"enabled": true
 		}
 	],
 	"_postman_variable_scope": "environment",
-	"_postman_exported_at": "2020-03-03T22:32:48.187Z",
-	"_postman_exported_using": "Postman/7.19.1"
+	"_postman_exported_at": "2022-10-20T18:36:45.391Z",
+	"_postman_exported_using": "Postman/10.0.1"
 }

--- a/public Admin APIs.postman_collection.json
+++ b/public Admin APIs.postman_collection.json
@@ -1,9 +1,8 @@
 {
 	"info": {
-		"_postman_id": "662b7f0e-c243-4fd2-8013-8122a39aa966",
+		"_postman_id": "42868158-22e6-4f0d-8581-8b72527d0805",
 		"name": "public Admin APIs",
-		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-		"_exporter_id": "14645211"
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
 	"item": [
 		{
@@ -995,10 +994,6 @@
 							{
 								"key": "Content-Type",
 								"value": "application/json"
-							},
-							{
-								"key": "Authorization",
-								"value": "Bearer {{auth-token-prod}}"
 							}
 						],
 						"body": {
@@ -1024,12 +1019,7 @@
 					"name": "DELETE Api Key",
 					"request": {
 						"method": "DELETE",
-						"header": [
-							{
-								"key": "Authorization",
-								"value": "Bearer {{auth-token-prod}}"
-							}
-						],
+						"header": [],
 						"url": {
 							"raw": "{{base-url}}/internal/api/v2/apiKeys/{{apiKeyId}}",
 							"host": [


### PR DESCRIPTION
These changes are meant to clean the `prod` Environment and the `Public Admin APIs` collection:

- Avoid having multiple authentication variables tokens and only use `apikey-auth`. This helps to avoid these kinds of configurations:
![Desktop-screenshot (15)](https://user-images.githubusercontent.com/1000281/197031625-0ae25a0f-6dee-4dd1-aa3a-6c2b4c092927.png)

- Add useful keys that are used across multiple requests:
  - `org-id`
  - `workspace-id`
  - `environment-id`
  - `traffictype-id`