### PR TITLE
Fix workspace template variable

### DIFF
--- a/public Admin APIs.postman_collection.json
+++ b/public Admin APIs.postman_collection.json
@@ -3019,7 +3019,7 @@
 				"method": "GET",
 				"header": [],
 				"url": {
-					"raw": "{{base-url}}/internal/api/v2/rolloutStatuses?wsId={wsId}",
+					"raw": "{{base-url}}/internal/api/v2/rolloutStatuses?wsId={{workspace-id}}",
 					"host": [
 						"{{base-url}}"
 					],
@@ -3032,7 +3032,7 @@
 					"query": [
 						{
 							"key": "wsId",
-							"value": "{wsId}"
+							"value": "{{workspace-id}}"
 						}
 					]
 				}


### PR DESCRIPTION
Use {{workspace-id}} instead of {wsId} to be consistent with template variables.