### PR TITLE
Update Before and After- APIs for Split Admins.postman_collection fro…

### DIFF
--- a/Before and After- APIs for Split Admins.postman_collection from harness-fme.json
+++ b/Before and After- APIs for Split Admins.postman_collection from harness-fme.json
@@ -1,11 +1,11 @@
 {
 	"info": {
-		"_postman_id": "ab25d079-4df6-4a1f-a439-7334f4af4926",
+		"_postman_id": "9ca705c6-5d09-45c1-91f2-313582994e39",
 		"name": "Before and After: APIs for Split Admins",
 		"description": "This collection provides working examples of the following:\n\n- Split API endpoints which will be deprecated after a Split account is migrated to Harness.\n    \n- Harness API endpoints that will replace the deprecated API endpoints.\n    \n\nIn each folder, you will see a \"Split (BEFORE)\" and \"Harness (AFTER)\" subfolder. These contain working examples of how Split Admin API tasks are performed in Split today, paired with working examples of how those same tasks can be performed in a Split account once it is migrated to Harness.\n\nThe folder names are based on endpoint names that Split adminstrators will be familiar with: while there is no \"Restrictions\" endpoint on the Harness side, we document the replacement for Split's Restrictions (project view permissions control) endpoints under Restrictions > Harness (AFTER).\n\n**Important: You will need a Harness API Key to operate against the new Harness API endpoints.**\n\nHarness API Keys are created in Harness under Acccount Settings > Access Control > Service Accounts. API Keys created there with the proper role and scope will be able to hit both the new endpoints on Harness, and the go-forward endpoints not being deprecated on Split.\n\nThe diagram below shows what type of API key can be used and when:\n\n<img src=\"https://content.pstmn.io/17e6376f-5a4b-4b7f-aa87-bd3619cf0b01/aGFybmVzcy12cy1zcGxpdC1hcGkta2V5cy12ZW5uLWRpYWdyYW0ucG5n\">",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-		"_exporter_id": "43022685",
-		"_collection_link": "https://www.postman.com/fme-tech-enablement/harness-fme/collection/qzyjhr8/before-and-after-apis-for-split-admins?action=share&source=collection_link&creator=43022685"
+		"_exporter_id": "42800031",
+		"_collection_link": "https://enable-success-together.postman.co/workspace/61b3163d-5f2f-4b4d-8c9f-b76ab9b1ad85/collection/42800031-9ca705c6-5d09-45c1-91f2-313582994e39?action=share&source=collection_link&creator=42800031"
 	},
 	"item": [
 		{
@@ -308,7 +308,8 @@
 											"value": ""
 										}
 									]
-								}
+								},
+								"description": "Doc link: [https://apidocs.harness.io/tag/User#operation/getAggregatedUsers](https://apidocs.harness.io/tag/User#operation/getAggregatedUsers)"
 							},
 							"response": []
 						},
@@ -347,7 +348,8 @@
 											"value": "{{Harness Account Identifier}}"
 										}
 									]
-								}
+								},
+								"description": "Docs link: [https://apidocs.harness.io/tag/User#operation/getAggregatedUser](https://apidocs.harness.io/tag/User#operation/getAggregatedUser)"
 							},
 							"response": []
 						},
@@ -431,7 +433,8 @@
 											"value": "{{Harness Account Identifier}}"
 										}
 									]
-								}
+								},
+								"description": "Docs link: [https://apidocs.harness.io/tag/User#operation/addUserToUserGroups](https://apidocs.harness.io/tag/User#operation/addUserToUserGroups)"
 							},
 							"response": []
 						},
@@ -473,7 +476,8 @@
 											"value": "{{Harness Account Identifier}}"
 										}
 									]
-								}
+								},
+								"description": "Docs link: [https://apidocs.harness.io/tag/User#operation/addUsers](https://apidocs.harness.io/tag/User#operation/addUsers)"
 							},
 							"response": []
 						},
@@ -506,7 +510,8 @@
 											"value": "{{Harness Account Identifier}}"
 										}
 									]
-								}
+								},
+								"description": "Docs link: [https://apidocs.harness.io/tag/Invite#operation/deleteInvite](https://apidocs.harness.io/tag/Invite#operation/deleteInvite)"
 							},
 							"response": []
 						},
@@ -539,7 +544,8 @@
 											"value": "{{Harness Account Identifier}}"
 										}
 									]
-								}
+								},
+								"description": "Docs link for \"Get pending users\": [https://apidocs.harness.io/tag/Invite#operation/getPendingUsersAggregated](https://apidocs.harness.io/tag/Invite#operation/getPendingUsersAggregated)\n\nSee also docs for the \"List Invites\" endpoint: [https://apidocs.harness.io/tag/Invite#operation/getInvites](https://apidocs.harness.io/tag/Invite#operation/getInvites)"
 							},
 							"response": []
 						}
@@ -554,7 +560,29 @@
 								"type": "string"
 							}
 						]
-					}
+					},
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"type": "text/javascript",
+								"packages": {},
+								"exec": [
+									""
+								]
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"type": "text/javascript",
+								"packages": {},
+								"exec": [
+									""
+								]
+							}
+						}
+					]
 				}
 			],
 			"description": "In Split, adding a user to the system automatically granted them a fixed set of global permissions. In Harness, you have **greater control over user permissions**. Refer to the section below this table to understand how **migrated users receive their permissions automatically**, and why you must **exercise more care when creating new users via the API**.\n\n**How Users Are Managed Differently in Split vs. Harness**\n\n| **Aspect** | **Split** (Before) | **Harness** (After) |\n| --- | --- | --- |\n| **User Roles** | Users were either **Administrators, Editors, or Viewers**, with hardcoded roles. | Users can be **assigned any role**, scoped to **any resource group**. Roles can be granted directly or through **group membership**. |\n| **User Scope** | Users had a **global account-level scope**. | Users exist at **Account, Organization, or Project levels**, allowing for more fine-grained access control. |\n| **Role Assignment** | Roles were **fixed per user** and could not be customized. | Roles are **assigned dynamically** based on **role bindings** that link users to **specific permissions and resource groups**. |\n| **User Creation** | Users were created via **direct API calls** with limited configuration options. | Users are created with **explicit role assignments** and can be added to groups that define their access. |\n| **Access Control** | Permissions were set **individually** per user or through environment-level settings. | Permissions are **inherited from roles and groups**, allowing for **centralized permission management**. |\n| **User Group Membership** | Groups were **lists of users** with no assigned permissions, except for Administrators. | Groups can be **granted roles**, and users automatically inherit the permissions assigned to the group. |\n\n---\n\n### **Observing Migrated Users vs. Creating New Users in Harness**\n\nWhen working with **users in Harness after migrating from Split**, it is essential to distinguish between how **migrated users** got their permissions and the steps you take to grant permissions when adding **new users post-migration**. Please pay particular attention to the way group memberships control most of this process. Let us know if you have questions!\n\n---\n\n### **Migrated Users: Automatically Configured with Correct Roles and Scope**\n\n- **During the migration**, all existing users from Split will be **pre-configured with the appropriate roles and scope** that match their previous access levels.\n    \n- These users will be assigned the correct **roles, resource groups, and permissions** to ensure they can continue working as they did in Split **without additional manual configuration**.\n    \n- If acting on a migrated user (e.g., modifying roles, adding them to new groups), ensure that **any changes align with their intended level of access** to avoid accidental over-permissioning or restriction.\n    \n\n---\n\n### **Creating New Users Post-Migration: Manual Role and Scope Assignment Required**\n\n- **New users do not inherit automatic permissions**—they must be explicitly assigned the correct **role(s) and scope**.\n    \n- When adding a new user, consider:\n    \n    - **Role Selection:** Assign the correct role based on what the user needs to do (e.g., `project_viewer`, `fme_manager`).\n        \n    - **Scope Definition:** Determine whether the user should have access at the **Account, Organization, or Project level**.\n        \n    - **Group Membership:** Adding users to **pre-configured groups** (e.g., `_all_account_fme_editors_`) can help apply the correct permissions more efficiently.\n        \n\n---\n\n### **Key Considerations for API Users**\n\n✔ **Migrated users already have the correct permissions—modify them only if necessary.**\n\n✔ **New users require manual role and scope assignment—apply permissions carefully.**\n\n✔ **Use role bindings to assign access in a structured, scalable way.**\n\n✔ **Double-check the scope of new users to ensure they have access to the right resources without over-permissioning.**"
@@ -739,7 +767,8 @@
 											"value": "{{Harness Account Identifier}}"
 										}
 									]
-								}
+								},
+								"description": "Docs link: [https://apidocs.harness.io/tag/User-Group#operation/getUserGroupList](https://apidocs.harness.io/tag/User-Group#operation/getUserGroupList)"
 							},
 							"response": []
 						},
@@ -772,7 +801,8 @@
 											"value": "{{Harness Account Identifier}}"
 										}
 									]
-								}
+								},
+								"description": "Docs link: [https://apidocs.harness.io/tag/User-Group#operation/getUserGroup](https://apidocs.harness.io/tag/User-Group#operation/getUserGroup)"
 							},
 							"response": []
 						},
@@ -810,7 +840,8 @@
 											"value": "{{Harness Account Identifier}}"
 										}
 									]
-								}
+								},
+								"description": "Docs link: [https://apidocs.harness.io/tag/User-Group#operation/postUserGroup](https://apidocs.harness.io/tag/User-Group#operation/postUserGroup)"
 							},
 							"response": []
 						},
@@ -848,7 +879,8 @@
 											"value": "{{Harness Account Identifier}}"
 										}
 									]
-								}
+								},
+								"description": "Docs link: [https://apidocs.harness.io/tag/User-Group#operation/putUserGroup](https://apidocs.harness.io/tag/User-Group#operation/putUserGroup)"
 							},
 							"response": []
 						},
@@ -881,7 +913,8 @@
 											"value": "{{Harness Account Identifier}}"
 										}
 									]
-								}
+								},
+								"description": "Docs link: [https://apidocs.harness.io/tag/User-Group#operation/deleteUserGroup](https://apidocs.harness.io/tag/User-Group#operation/deleteUserGroup)"
 							},
 							"response": []
 						}
@@ -896,7 +929,29 @@
 								"type": "string"
 							}
 						]
-					}
+					},
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"type": "text/javascript",
+								"packages": {},
+								"exec": [
+									""
+								]
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"type": "text/javascript",
+								"packages": {},
+								"exec": [
+									""
+								]
+							}
+						}
+					]
 				}
 			],
 			"description": "### **How Groups Are Administered Differently in Split vs. Harness**\n\n| **Aspect** | **Split (Before)** | **Harness (After)** |\n| --- | --- | --- |\n| **Group Functionality** | Groups are simple **lists of users**, except for the Administrators group. | Groups can have **role bindings**, meaning they can grant permissions. |\n| **Permissions** | Groups themselves **do not have roles**; permissions are granted via environment/object-level settings. | Groups can be assigned **one or more roles**, defining what actions members can perform. |\n| **Scope** | Groups are **global (account-level only)**—they cannot be scoped to a project. | Groups can exist at **Account, Organization, or Project level**, providing flexibility. |\n| **Creating a Group** | Admins create a group with only a **name and description**. | Admins create a group and can assign **users, roles, and notification settings**. |\n| **Managing Membership** | Users are **added or removed manually** through the Users API. | Users can be added or removed, and their **permissions are determined by the group's assigned roles**. |\n| **Using Groups for Permissions** | Groups grant permissions **only when used in environment or object-level entries**. | Groups can be assigned **roles directly**, making them the preferred way to manage access. |\n| **Default Groups in Migration** | Only the **Administrators group** had special privileges. | Migrated users are assigned to **new default groups**: `_all_account_admins_`, `_all_account_fme_editors_`, `_all_account_fme_viewers_`. |\n\n---\n\n### **Key Takeaways**\n\n✔ **Split groups were just lists of users; Harness groups can have assigned roles.**\n\n✔ **Harness supports hierarchical groups at different scopes (Account, Organization, Project).**\n\n✔ **Within Harness, groups are the preferred way to manage permissions, reducing manual role assignments.**"
@@ -1089,7 +1144,8 @@
 											"value": "{{Harness Organization Identifier}}"
 										}
 									]
-								}
+								},
+								"description": "Docs link: [https://apidocs.harness.io/tag/Project#operation/getProject](https://apidocs.harness.io/tag/Project#operation/getProject)"
 							},
 							"response": []
 						},
@@ -1131,7 +1187,8 @@
 											"value": "{{Harness Organization Identifier}}"
 										}
 									]
-								}
+								},
+								"description": "Docs link: [https://apidocs.harness.io/tag/Project#operation/postProject](https://apidocs.harness.io/tag/Project#operation/postProject)"
 							},
 							"response": []
 						},
@@ -1174,7 +1231,8 @@
 											"value": "{{Harness Organization Identifier}}"
 										}
 									]
-								}
+								},
+								"description": "Docs link: [https://apidocs.harness.io/tag/Project#operation/putProject](https://apidocs.harness.io/tag/Project#operation/putProject)"
 							},
 							"response": []
 						},
@@ -1208,7 +1266,8 @@
 											"value": "{{Harness Organization Identifier}}"
 										}
 									]
-								}
+								},
+								"description": "Docs link: [https://apidocs.harness.io/tag/Project#operation/deleteProject](https://apidocs.harness.io/tag/Project#operation/deleteProject)"
 							},
 							"response": []
 						}
@@ -1223,7 +1282,29 @@
 								"type": "string"
 							}
 						]
-					}
+					},
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"type": "text/javascript",
+								"packages": {},
+								"exec": [
+									""
+								]
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"type": "text/javascript",
+								"packages": {},
+								"exec": [
+									""
+								]
+							}
+						}
+					]
 				}
 			],
 			"description": "### **How Projects Are Managed in Split vs. Harness**\n\n| **Aspect** | **Split** | **Harness** |\n| --- | --- | --- |\n| **Terminology** | Projects were called **Workspaces** until late 2024, when interfaces and documentation switched to the term **Projects**. The API retained the term **Workspaces.** | Projects are called **Projects** and are integrated into the **RBAC hierarchy** (Account → Organization → Project). |\n| **Scope & Structure** | Workspaces are managed independently and have no explicit hierarchy. | Projects exist within **Organizations** and **Accounts**, enabling structured role-based access. |\n| **Access Management** | Access is managed via **Project View Restrictions**, which require explicit API calls to set visibility. | Projects are **restricted by default**, and access is controlled using **RBAC role assignments and resource groups**. |\n| **Permissions & Roles** | Permissions are assigned per user or group via manual restrictions. | Permissions are assigned through **Roles and Resource Groups**, which can be inherited or explicitly defined. |\n| **Creating a Project** | Creating a new project (workspace) requires a **direct API call**, specifying only a name and optional settings. | Creating a project involves defining its **scope within the Account/Organization**, and **RBAC settings determine who can access and modify it**. |\n| **Project Restrictions** | Open workspaces are **the default**, but can be explicitly restricted via API. | Projects are **restricted by default**, and broad access must be explicitly granted via role bindings. |\n\n---\n\n### **Key Takeaways**\n\n✔ **Harness projects follow a structured hierarchy (Account → Organization → Project), unlike Split’s flat workspace model.**  \n  \n✔ **RBAC replaces manual project restrictions, offering more flexible and scalable access management.**  \n  \n✔ **Projects are restricted by default in Harness, whereas Split workspaces are open by default unless restricted.**"
@@ -1360,7 +1441,8 @@
 											"value": "{{Harness Account Identifier}}"
 										}
 									]
-								}
+								},
+								"description": "Docs link: [https://apidocs.harness.io/tag/Service-Account#operation/createServiceAccount](https://apidocs.harness.io/tag/Service-Account#operation/createServiceAccount)"
 							},
 							"response": []
 						},
@@ -1398,7 +1480,8 @@
 											"value": "{{Harness Account Identifier}}"
 										}
 									]
-								}
+								},
+								"description": "Docs link: [https://apidocs.harness.io/tag/ApiKey#operation/createApiKey](https://apidocs.harness.io/tag/ApiKey#operation/createApiKey)"
 							},
 							"response": []
 						},
@@ -1436,7 +1519,8 @@
 											"value": "{{Harness Account Identifier}}"
 										}
 									]
-								}
+								},
+								"description": "Docs link: [https://apidocs.harness.io/tag/Role-Assignments#operation/postRoleAssignment](https://apidocs.harness.io/tag/Role-Assignments#operation/postRoleAssignment)"
 							},
 							"response": []
 						},
@@ -1474,7 +1558,8 @@
 											"value": "{{Harness Account Identifier}}"
 										}
 									]
-								}
+								},
+								"description": "Docs link: [https://apidocs.harness.io/tag/Token#operation/createToken](https://apidocs.harness.io/tag/Token#operation/createToken)"
 							},
 							"response": []
 						},
@@ -1530,7 +1615,8 @@
 											"value": "{{Harness Rotate Timestamp}}"
 										}
 									]
-								}
+								},
+								"description": "Docs link: [https://apidocs.harness.io/tag/Token#operation/rotateToken](https://apidocs.harness.io/tag/Token#operation/rotateToken)"
 							},
 							"response": []
 						},
@@ -1571,7 +1657,8 @@
 											"value": "{{Harness Account Identifier}}"
 										}
 									]
-								}
+								},
+								"description": "Docs link for \"Get Service Accounts\": [https://apidocs.harness.io/tag/Service-Account#operation/listServiceAccount](https://apidocs.harness.io/tag/Service-Account#operation/listServiceAccount)\n\nSee also docs for \"List Aggregated Service Accounts\" [https://apidocs.harness.io/tag/Service-Account#operation/listAggregatedServiceAccounts](https://apidocs.harness.io/tag/Service-Account#operation/listAggregatedServiceAccounts)"
 							},
 							"response": []
 						},
@@ -1620,7 +1707,8 @@
 											"value": "{{Harness Parent Identifier}}"
 										}
 									]
-								}
+								},
+								"description": "Docs link: [https://apidocs.harness.io/tag/ApiKey#operation/listApiKeys_1](https://apidocs.harness.io/tag/ApiKey#operation/listApiKeys_1)\n\nSee also docs for aggregated list: [https://apidocs.harness.io/tag/ApiKey#operation/listApiKeys](https://apidocs.harness.io/tag/ApiKey#operation/listApiKeys)"
 							},
 							"response": []
 						},
@@ -1648,14 +1736,14 @@
 									}
 								},
 								"url": {
-									"raw": "{{Harness API Base URL}}/apikey/aggregate/test_api_key?accountIdentifier={{Harness Account Identifier}}&apiKeyType={{Harness API Key Type}}&parentIdentifier={{Harness Parent Identifier}}",
+									"raw": "{{Harness API Base URL}}/apikey/aggregate/{{Harness API Key Identifier}}?accountIdentifier={{Harness Account Identifier}}&apiKeyType={{Harness API Key Type}}&parentIdentifier={{Harness Parent Identifier}}",
 									"host": [
 										"{{Harness API Base URL}}"
 									],
 									"path": [
 										"apikey",
 										"aggregate",
-										"test_api_key"
+										"{{Harness API Key Identifier}}"
 									],
 									"query": [
 										{
@@ -1671,7 +1759,8 @@
 											"value": "{{Harness Parent Identifier}}"
 										}
 									]
-								}
+								},
+								"description": "Docs link: [https://apidocs.harness.io/tag/ApiKey#operation/getAggregatedApiKey](https://apidocs.harness.io/tag/ApiKey#operation/getAggregatedApiKey)"
 							},
 							"response": []
 						},
@@ -1725,7 +1814,8 @@
 											"value": "{{Harness API Key Identifier}}"
 										}
 									]
-								}
+								},
+								"description": "Docs link: [https://apidocs.harness.io/tag/Token#operation/listAggregatedTokens](https://apidocs.harness.io/tag/Token#operation/listAggregatedTokens)"
 							},
 							"response": []
 						},
@@ -1764,7 +1854,8 @@
 											"value": "{{Harness Account Identifier}}"
 										}
 									]
-								}
+								},
+								"description": "Docs link: [https://apidocs.harness.io/tag/Role-Assignments#operation/deleteRoleAssignment](https://apidocs.harness.io/tag/Role-Assignments#operation/deleteRoleAssignment)"
 							},
 							"response": []
 						},
@@ -1815,7 +1906,8 @@
 											"value": "{{Harness API Key Identifier}}"
 										}
 									]
-								}
+								},
+								"description": "Docs link: [https://apidocs.harness.io/tag/Token#operation/deleteToken](https://apidocs.harness.io/tag/Token#operation/deleteToken)"
 							},
 							"response": []
 						},
@@ -1862,7 +1954,8 @@
 											"value": "{{Harness Parent Identifier}}"
 										}
 									]
-								}
+								},
+								"description": "Docs link: [https://apidocs.harness.io/tag/ApiKey#operation/deleteApiKey](https://apidocs.harness.io/tag/ApiKey#operation/deleteApiKey)"
 							},
 							"response": []
 						},
@@ -1901,12 +1994,13 @@
 											"value": "{{Harness Account Identifier}}"
 										}
 									]
-								}
+								},
+								"description": "Docs link: [https://apidocs.harness.io/tag/Service-Account#operation/deleteServiceAccount](https://apidocs.harness.io/tag/Service-Account#operation/deleteServiceAccount)"
 							},
 							"response": []
 						}
 					],
-					"description": "The `/serviceaccount`, `/apikey`, `/token`, and `/roleassignments` endpoints here replace the Split `/apiKeys` endpoint after migration to Harness.\n\n## API Key Structure: Service Account > API Key > Token\n\nWhile Split Admin API keys were a single entity, in Harness they consist of three entities at different levels for greater control.\n\n## **1\\. Service Account Level**\n\n- **Primary Role:** Defines **who** (a machine identity) is making API requests.\n    \n- **What Can Be Set Here?**\n    \n    - **Permissions & Roles**: Permissions are assigned at the **Service Account level**, not at the API Key or Token level.\n        \n    - **Scope**: A Service Account can be scoped at **Account, Organization, or Project level**.\n        \n    - **Ownership of API Keys**: Each API Key is linked to a specific **Service Account**.\n        \n- **Key Takeaway:** **Permissions are set at the Service Account level, and all API Keys created under it inherit these permissions.**\n    \n\n## **2\\. API Key Level**\n\n- **Primary Role:** Acts as an **access credential** tied to a Service Account.\n    \n- **What Can Be Set Here?**\n    \n    - **Scope**: An API Key belongs to a specific **Service Account**, meaning it has the same permissions.\n        \n    - **Token Generation**: Each API Key can have multiple **Tokens** for authentication.\n        \n    - **Expiry Control**: API Keys **do not expire** unless explicitly deleted.\n        \n- **Key Takeaway:** **API Keys provide authentication, but they do not define permissions themselves.**\n    \n\n## **3\\. Token Level**\n\n- **Primary Role:** A short-lived, displayed-once **credential** used to authenticate requests.\n    \n- **What Can Be Set Here?**\n    \n    - **Expiration Date**: Tokens can have an **expiration time** (or be permanent).\n        \n    - **One-Time Visibility**: A token is **only shown once** when created.\n        \n    - **Rotatable**: Tokens can be **revoked and rotated** without affecting the API Key.\n        \n- **Key Takeaway:** **Tokens are temporary authentication mechanisms derived from API Keys. They enable secure, limited-time API access.**\n    \n\n### **Summary: How They Work Together**\n\n| **Level** | **Purpose** | **What Can Be Set Here?** |\n| --- | --- | --- |\n| **Service Account** | Defines identity & permissions | **Roles, permissions, and scope** (Account/Org/Project) |\n| **API Key** | Authentication credential | **Scoped to a Service Account** (inherits permissions) |\n| **Token** | Temporary authentication | **Expiration, rotation, and single-use access** |",
+					"description": "The `/serviceaccount`, `/apikey`, `/token`, and `/roleassignments` endpoints here replace the Split `/apiKeys` endpoint after migration to Harness.\n\nHere are the **Harness API equivalents** for replacing the **Split API key creation process**, which now requires **three components**:\n\n1. **Service Account**\n    \n2. **API Key**\n    \n3. **Token**\n    \n\n---\n\n## **Step 1: Create a Service Account**\n\nBefore creating an API key, you must first create a **Service Account** since API keys are scoped under a **Service Account**.\n\n👉 **Save the** **`identifier`** **from the response to use in the next step as** `SERVICE_ACCOUNT_ID`\n\n---\n\n## **Step 2: Create an API Key**\n\nNow that the Service Account is created, you can generate an **API Key**.\n\n👉 **Save the** **`identifier`** **from the response to use in the next step as** `API_KEY_ID`\n\n---\n\n## **Step 3: Create a Token for the API Key**\n\nFinally, you need to create a **Token** to use with the API Key.\n\n👉 **Save the** **`token`** **value to use in API calls as the bearer token.**\n\n---\n\n# More Details on Harness API Key Structure\n\n## Service Account > API Key > Token\n\nWhile Split Admin API keys were a single entity, in Harness they consist of three entities at different levels for greater control.\n\n## **1\\. Service Account Level**\n\n- **Primary Role:** Defines **who** (a machine identity) is making API requests.\n    \n- **What Can Be Set Here?**\n    \n    - **Permissions & Roles**: Permissions are assigned at the **Service Account level**, not at the API Key or Token level.\n        \n    - **Scope**: A Service Account can be scoped at **Account, Organization, or Project level**.\n        \n    - **Ownership of API Keys**: Each API Key is linked to a specific **Service Account**.\n        \n- **Key Takeaway:** **Permissions are set at the Service Account level, and all API Keys created under it inherit these permissions.**\n    \n\n## **2\\. API Key Level**\n\n- **Primary Role:** Acts as an **access credential** tied to a Service Account.\n    \n- **What Can Be Set Here?**\n    \n    - **Scope**: An API Key belongs to a specific **Service Account**, meaning it has the same permissions.\n        \n    - **Token Generation**: Each API Key can have multiple **Tokens** for authentication.\n        \n    - **Expiry Control**: API Keys **do not expire** unless explicitly deleted.\n        \n- **Key Takeaway:** **API Keys provide authentication, but they do not define permissions themselves.**\n    \n\n## **3\\. Token Level**\n\n- **Primary Role:** A short-lived, displayed-once **credential** used to authenticate requests.\n    \n- **What Can Be Set Here?**\n    \n    - **Expiration Date**: Tokens can have an **expiration time** (or be permanent).\n        \n    - **One-Time Visibility**: A token is **only shown once** when created.\n        \n    - **Rotatable**: Tokens can be **revoked and rotated** without affecting the API Key.\n        \n- **Key Takeaway:** **Tokens are temporary authentication mechanisms derived from API Keys. They enable secure, limited-time API access.**\n    \n\n### **Summary: How They Work Together**\n\n| **Level** | **Purpose** | **What Can Be Set Here?** |\n| --- | --- | --- |\n| **Service Account** | Defines identity & permissions | **Roles, permissions, and scope** (Account/Org/Project) |\n| **API Key** | Authentication credential | **Scoped to a Service Account** (inherits permissions) |\n| **Token** | Temporary authentication | **Expiration, rotation, and single-use access** |",
 					"auth": {
 						"type": "bearer",
 						"bearer": [
@@ -1916,7 +2010,29 @@
 								"type": "string"
 							}
 						]
-					}
+					},
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"type": "text/javascript",
+								"packages": {},
+								"exec": [
+									""
+								]
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"type": "text/javascript",
+								"packages": {},
+								"exec": [
+									""
+								]
+							}
+						}
+					]
 				}
 			],
 			"description": "The table below provides a high-level \"before and after\" comparison. Please see the Split (BEFORE) and Harness (AFTER) folders below this one for more specific details.\n\n### **API Key Management in Split vs. Harness**\n\n| **Aspect** | **Split (Before)** | **Harness (After)** |\n| --- | --- | --- |\n| **Permission Management** | API keys have direct permissions. Each key is assigned roles and scopes individually. | Permissions are managed at the **Service Account** level. API keys inherit permissions from their parent Service Account. |\n| **Scope Management** | API keys define their own scope (workspace, users, groups, etc.). | Scope is determined by **Resource Groups**, which define what a role can access. |\n| **User/Principal Management** | No concept of Service Accounts. API keys function independently. | API keys belong to a **Service Account**, which acts as the principal entity managing access. |\n| **Key Expiration & Rotation** | No built-in expiration mechanism. Rotation requires manually deleting and recreating the key. | Tokens provide built-in expiration and can be rotated without deleting the API key. |\n| **Access Control** | API keys must be manually added to permission lists to maintain access to restricted resources. | Access is determined by **Role Assignments (Role Bindings)**, which associate a user, group, or Service Account with a role and resource group. |\n| **Security Model** | Less granular; API keys can be overly permissive. | More granular; permissions are set at the **Service Account** level, reducing excessive privileges. |\n| **Hierarchy of API Key Management** | Flat structure—each API key operates independently. | Hierarchical structure—Service Accounts own API keys, and API keys generate tokens for secure authentication. |"
@@ -2075,7 +2191,8 @@
 											"value": "{{Harness Account Identifier}}"
 										}
 									]
-								}
+								},
+								"description": "Docs link: [https://apidocs.harness.io/tag/Role-Assignments#operation/postRoleAssignments](https://apidocs.harness.io/tag/Role-Assignments#operation/postRoleAssignments)"
 							},
 							"response": []
 						},
@@ -2116,7 +2233,8 @@
 											"value": "{{Harness Account Identifier}}"
 										}
 									]
-								}
+								},
+								"description": "Docs link: [https://apidocs.harness.io/tag/Role-Assignments#operation/getRoleAssignmentList](https://apidocs.harness.io/tag/Role-Assignments#operation/getRoleAssignmentList)"
 							},
 							"response": []
 						},
@@ -2155,7 +2273,8 @@
 											"value": "{{Harness Account Identifier}}"
 										}
 									]
-								}
+								},
+								"description": "Docs link: [https://apidocs.harness.io/tag/Role-Assignments#operation/deleteRoleAssignment](https://apidocs.harness.io/tag/Role-Assignments#operation/deleteRoleAssignment)"
 							},
 							"response": []
 						},
@@ -2193,7 +2312,8 @@
 											"value": "{{Harness Account Identifier}}"
 										}
 									]
-								}
+								},
+								"description": "Docs link: [https://apidocs.harness.io/tag/Roles#operation/postRole](https://apidocs.harness.io/tag/Roles#operation/postRole)"
 							},
 							"response": []
 						},
@@ -2232,7 +2352,8 @@
 											"value": "{{Harness Account Identifier}}"
 										}
 									]
-								}
+								},
+								"description": "Docs link: [https://apidocs.harness.io/tag/Roles#operation/putRole](https://apidocs.harness.io/tag/Roles#operation/putRole)"
 							},
 							"response": []
 						},
@@ -2273,7 +2394,8 @@
 											"value": "{{Harness Account Identifier}}"
 										}
 									]
-								}
+								},
+								"description": "Docs link: [https://apidocs.harness.io/tag/Roles#operation/getRoleList](https://apidocs.harness.io/tag/Roles#operation/getRoleList)"
 							},
 							"response": []
 						},
@@ -2312,7 +2434,8 @@
 											"value": "{{Harness Account Identifier}}"
 										}
 									]
-								}
+								},
+								"description": "Docs link: [https://apidocs.harness.io/tag/Roles#operation/deleteRole](https://apidocs.harness.io/tag/Roles#operation/deleteRole)"
 							},
 							"response": []
 						},
@@ -2350,7 +2473,8 @@
 											"value": "{{Harness Account Identifier}}"
 										}
 									]
-								}
+								},
+								"description": "Docs link: [https://apidocs.harness.io/tag/Harness-Resource-Group#operation/createResourceGroupV2](https://apidocs.harness.io/tag/Harness-Resource-Group#operation/createResourceGroupV2)"
 							},
 							"response": []
 						},
@@ -2389,7 +2513,8 @@
 											"value": "{{Harness Account Identifier}}"
 										}
 									]
-								}
+								},
+								"description": "Docs link: [https://apidocs.harness.io/tag/Harness-Resource-Group#operation/updateResourceGroupV2](https://apidocs.harness.io/tag/Harness-Resource-Group#operation/updateResourceGroupV2)"
 							},
 							"response": []
 						},
@@ -2430,7 +2555,8 @@
 											"value": "{{Harness Account Identifier}}"
 										}
 									]
-								}
+								},
+								"description": "Docs link: [https://apidocs.harness.io/tag/Harness-Resource-Group#operation/getResourceGroupListV2](https://apidocs.harness.io/tag/Harness-Resource-Group#operation/getResourceGroupListV2)"
 							},
 							"response": []
 						},
@@ -2469,7 +2595,8 @@
 											"value": "{{Harness Account Identifier}}"
 										}
 									]
-								}
+								},
+								"description": "Docs link: [https://apidocs.harness.io/tag/Harness-Resource-Group#operation/deleteResourceGroupV2](https://apidocs.harness.io/tag/Harness-Resource-Group#operation/deleteResourceGroupV2)"
 							},
 							"response": []
 						}
@@ -2484,12 +2611,44 @@
 								"type": "string"
 							}
 						]
-					}
+					},
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"type": "text/javascript",
+								"packages": {},
+								"exec": [
+									""
+								]
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"type": "text/javascript",
+								"packages": {},
+								"exec": [
+									""
+								]
+							}
+						}
+					]
 				}
 			],
 			"description": "### **Before and After of Restrictions in Split vs. Harness**\n\n#### **Before (Split)**\n\n- **Restrictions were applied at the project (workspace) level** using an API endpoint.\n    \n- To restrict a project, users had to manually specify:\n    \n    - The list of users/groups allowed access.\n        \n    - The **Administrator group** as an allowed subject.\n        \n    - The **API key used to set restrictions** had to be explicitly added as an allowed subject.\n        \n- Access control was managed via the **resourcePermissions.view** field.\n    \n- Open projects had no access restrictions, while restricted ones required explicit access grants​\n    \n\n#### **After (Harness - RBAC Model)**\n\n- **Permissions are captured in a role** (e.g., `project_viewer`, `fme_manager`).\n    \n- **Scope is captured in a resource group** (e.g., `_fme_all_resources` for all features within a project).\n    \n- **Roles and resource groups are assigned to a user (or other principal) via a role binding**.\n    \n- Projects are **restricted by default** in Harness. If a migrated project was open in Split, Harness assigns broad access to mimic that behavior.\n    \n- To restrict access post-migration, the **default role bindings for all users/groups must be removed**, and explicit assignments should be made​\n    \n\n### **Before and After of Restrictions in Split vs. Harness**\n\n#### **Before (Split)**\n\n- **Restrictions were applied at the project (workspace) level** using an API endpoint.\n    \n- To restrict a project, users had to manually specify:\n    \n    - The list of users/groups allowed access.\n        \n    - The **Administrator group** as an allowed subject.\n        \n    - The **API key used to set restrictions** had to be explicitly added as an allowed subject.\n        \n- Access control was managed via the **resourcePermissions.view** field.\n    \n- Open projects had no access restrictions, while restricted ones required explicit access grants.\n    \n\n#### **After (Harness - RBAC Model)**\n\n- **Permissions are captured in a role** (e.g., `project_viewer`, `fme_manager`).\n    \n- **Scope is captured in a resource group** (e.g., `_fme_all_resources` for all features within a project).\n    \n- **Roles and resource groups are assigned to a user (or other principal) via a role binding**.\n    \n- Projects are **restricted by default** in Harness. If a migrated project was open in Split, Harness assigns broad access to mimic that behavior.\n    \n- To restrict access post-migration, the **default role bindings for all users/groups in that project must be removed**, and explicit assignments should be made.\n    \n\n---\n\nThese resources in the Harness Developer Hub provide more information on managing roles, resource groups, and role assignments within Harness.\n\n- **Roles**: [Manage roles](https://developer.harness.io/docs/platform/role-based-access-control/add-manage-roles/)\n    \n- **Resource Groups**: [Manage resource groups](https://developer.harness.io/docs/platform/role-based-access-control/add-resource-groups/)\n    \n- **Role Assignments (Role Binding)**: [Role-based access control (RBAC) in Harness](https://developer.harness.io/docs/platform/role-based-access-control/rbac-in-harness/)"
 		}
 	],
+	"auth": {
+		"type": "bearer",
+		"bearer": [
+			{
+				"key": "token",
+				"value": "{{",
+				"type": "string"
+			}
+		]
+	},
 	"event": [
 		{
 			"listen": "prerequest",
@@ -2515,148 +2674,119 @@
 	"variable": [
 		{
 			"key": "Split API Base URL",
-			"value": "https://api.split.io/internal/api/v2",
-			"type": "default"
+			"value": "https://api.split.io/internal/api/v2"
 		},
 		{
 			"key": "Harness Account Identifier",
-			"value": "",
-			"type": "default"
+			"value": ""
 		},
 		{
 			"key": "Harness API Base URL",
-			"value": "https://app.harness.io/ng/api",
-			"type": "default"
+			"value": "https://app.harness.io/ng/api"
 		},
 		{
 			"key": "Harness API Token",
-			"value": "",
-			"type": "default"
+			"value": ""
 		},
 		{
 			"key": "Harness User Identifier",
-			"value": "",
-			"type": "default"
+			"value": ""
 		},
 		{
 			"key": "Split API Token",
-			"value": "",
-			"type": "string"
+			"value": ""
 		},
 		{
 			"key": "Split User Identifier",
-			"value": "",
-			"type": "default"
+			"value": ""
 		},
 		{
 			"key": "Split Pending User Identifier",
-			"value": "",
-			"type": "default"
+			"value": ""
 		},
 		{
 			"key": "Split Group Identifier",
-			"value": "",
-			"type": "default"
+			"value": ""
 		},
 		{
 			"key": "Harness Group Identifier",
-			"value": "",
-			"type": "default"
+			"value": ""
 		},
 		{
 			"key": "Split Workspace Identifier",
-			"value": "",
-			"type": "default"
+			"value": ""
 		},
 		{
 			"key": "Harness Organization Identifier",
-			"value": "",
-			"type": "default"
+			"value": ""
 		},
 		{
 			"key": "Harness Project Identifier",
-			"value": "",
-			"type": "default"
+			"value": ""
 		},
 		{
 			"key": "Split Environment Identifier",
-			"value": "",
-			"type": "string"
+			"value": ""
 		},
 		{
 			"key": "Split Admin API Key Identifier",
-			"value": "",
-			"type": "default"
+			"value": ""
 		},
 		{
 			"key": "Harness Auth Base URL",
-			"value": "https://app.harness.io/ng/api",
-			"type": "string"
+			"value": "https://app.harness.io/authz/api"
 		},
 		{
 			"key": "Harness Resource Group Base URL",
-			"value": "https://app.harness.io/resourcegroup/api/v2",
-			"type": "string"
+			"value": "https://app.harness.io/resourcegroup/api/v2"
 		},
 		{
 			"key": "Harness API Key Identifier",
-			"value": "",
-			"type": "default"
+			"value": ""
 		},
 		{
 			"key": "Harness Token Identifier",
-			"value": "",
-			"type": "default"
+			"value": ""
 		},
 		{
 			"key": "Harness Parent Identifier",
-			"value": "",
-			"type": "default"
+			"value": ""
 		},
 		{
 			"key": "Harness Rotate Timestamp",
-			"value": "",
-			"type": "default"
+			"value": ""
 		},
 		{
 			"key": "Harness API Key Type",
-			"value": "SERVICE_ACCOUNT",
-			"type": "default"
+			"value": "SERVICE_ACCOUNT"
 		},
 		{
 			"key": "Harness Service Account Identifier",
-			"value": "",
-			"type": "default"
+			"value": ""
 		},
 		{
 			"key": "Harness Role Assignment Identifier",
-			"value": "",
-			"type": "default"
+			"value": ""
 		},
 		{
 			"key": "Split Resource Type",
-			"value": "workspace",
-			"type": "default"
+			"value": "workspace"
 		},
 		{
 			"key": "Split Resource Identifier",
-			"value": "",
-			"type": "default"
+			"value": ""
 		},
 		{
 			"key": "Harness Role Identifier",
-			"value": "",
-			"type": "default"
+			"value": ""
 		},
 		{
 			"key": "Harness Resource Group Identifier",
-			"value": "",
-			"type": "default"
+			"value": ""
 		},
 		{
 			"key": "Harness Invite Identifier",
-			"value": "",
-			"type": "default"
+			"value": ""
 		}
 	]
 }


### PR DESCRIPTION
Added doc links for all Harness APIs in the collection. 
Fixed Harness Auth Base URL and Harness Resource Group Base URL
Made other minor corrections throughout.
This exact update was posted as an overwrite of the Public postman collection 24 Mar 2025, 9:43 PM (Pacific time) at https://www.postman.com/fme-tech-enablement/harness-fme/collection/asyzcuq/before-and-after-apis-for-split-admins
(Users of the public collection can use the diff here to see what was changed there as well... apologies for not being able use the native Postman diffing capability due to our config!)
Questions? David.Karow@harness.io