### PR TITLE
Update Before and After- APIs for Split Admins postman collection

### DIFF
--- a/Before and After- APIs for Split Admins.postman_collection from harness-fme.json
+++ b/Before and After- APIs for Split Admins.postman_collection from harness-fme.json
@@ -1,11 +1,11 @@
 {
 	"info": {
-		"_postman_id": "9ca705c6-5d09-45c1-91f2-313582994e39",
+		"_postman_id": "24943141-a97b-4bf3-a357-26802b0efc8e",
 		"name": "Before and After: APIs for Split Admins",
 		"description": "This collection provides working examples of the following:\n\n- Split API endpoints which will be deprecated after a Split account is migrated to Harness.\n    \n- Harness API endpoints that will replace the deprecated API endpoints.\n    \n\nIn each folder, you will see a \"Split (BEFORE)\" and \"Harness (AFTER)\" subfolder. These contain working examples of how Split Admin API tasks are performed in Split today, paired with working examples of how those same tasks can be performed in a Split account once it is migrated to Harness.\n\nThe folder names are based on endpoint names that Split adminstrators will be familiar with: while there is no \"Restrictions\" endpoint on the Harness side, we document the replacement for Split's Restrictions (project view permissions control) endpoints under Restrictions > Harness (AFTER).\n\n**Important: You will need a Harness API Key to operate against the new Harness API endpoints.**\n\nHarness API Keys are created in Harness under Acccount Settings > Access Control > Service Accounts. API Keys created there with the proper role and scope will be able to hit both the new endpoints on Harness, and the go-forward endpoints not being deprecated on Split.\n\nThe diagram below shows what type of API key can be used and when:\n\n<img src=\"https://content.pstmn.io/17e6376f-5a4b-4b7f-aa87-bd3619cf0b01/aGFybmVzcy12cy1zcGxpdC1hcGkta2V5cy12ZW5uLWRpYWdyYW0ucG5n\">",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-		"_exporter_id": "42800031",
-		"_collection_link": "https://enable-success-together.postman.co/workspace/61b3163d-5f2f-4b4d-8c9f-b76ab9b1ad85/collection/42800031-9ca705c6-5d09-45c1-91f2-313582994e39?action=share&source=collection_link&creator=42800031"
+		"_exporter_id": "43022685",
+		"_collection_link": "https://www.postman.com/harness-fme-enablement/workspace/harness-fme/collection/43022685-24943141-a97b-4bf3-a357-26802b0efc8e?action=share&source=collection_link&creator=43022685"
 	},
 	"item": [
 		{
@@ -20,9 +20,9 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "{{Split API Base URL}}/users",
+									"raw": "{{Split_API_Base_URL}}/users",
 									"host": [
-										"{{Split API Base URL}}"
+										"{{Split_API_Base_URL}}"
 									],
 									"path": [
 										"users"
@@ -55,9 +55,63 @@
 										}
 									]
 								},
-								"description": "List all active, deactivated, and pending users in the organization.\n\nAlso supports getting a list of users in a group with optional query param, group_id."
+								"description": "List all active, deactivated, and pending users in the organization.\n\nAlso supports getting a list of users in a group with optional query param, group_id.\n\n**Legacy Split API doc link:** [https://docs.split.io/reference/list-users](https://docs.split.io/reference/list-users)"
 							},
-							"response": []
+							"response": [
+								{
+									"name": "200 OK - List of Users",
+									"originalRequest": {
+										"method": "GET",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"url": {
+											"raw": "{{Split_API_Base_URL}}/users",
+											"host": [
+												"{{Split_API_Base_URL}}"
+											],
+											"path": [
+												"users"
+											],
+											"query": [
+												{
+													"key": "status",
+													"value": "PENDING|ACTIVE|DEACTIVATED",
+													"disabled": true
+												},
+												{
+													"key": "limit",
+													"value": "20",
+													"disabled": true
+												},
+												{
+													"key": "after",
+													"value": "",
+													"disabled": true
+												},
+												{
+													"key": "before",
+													"value": "",
+													"disabled": true
+												},
+												{
+													"key": "group_id",
+													"value": "",
+													"disabled": true
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [],
+									"cookie": [],
+									"body": "{\n  \"objects\": [\n    {\n      \"id\": \"user_12345\",\n      \"email\": \"user1@example.com\",\n      \"status\": \"ACTIVE\",\n      \"groups\": [\"group_1\", \"group_2\"],\n      \"createdAt\": \"2023-01-01T12:00:00Z\"\n    },\n    {\n      \"id\": \"user_67890\",\n      \"email\": \"user2@example.com\",\n      \"status\": \"PENDING\",\n      \"groups\": [\"group_1\"],\n      \"createdAt\": \"2023-01-02T12:00:00Z\"\n    }\n  ],\n  \"totalCount\": 2,\n  \"limit\": 20,\n  \"offset\": 0\n}"
+								}
+							]
 						},
 						{
 							"name": "Get User",
@@ -65,18 +119,63 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "{{Split API Base URL}}/users/{{Split User Identifier}}",
+									"raw": "{{Split_API_Base_URL}}/users/{{Split_User_Identifier}}",
 									"host": [
-										"{{Split API Base URL}}"
+										"{{Split_API_Base_URL}}"
 									],
 									"path": [
 										"users",
-										"{{Split User Identifier}}"
+										"{{Split_User_Identifier}}"
 									]
 								},
-								"description": "Get a user by their user Id."
+								"description": "Get a user by their user Id.\n\n**Legacy Split API doc link:** [https://docs.split.io/reference/get-user](https://docs.split.io/reference/get-user)"
 							},
-							"response": []
+							"response": [
+								{
+									"name": "200 OK - User found",
+									"originalRequest": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "Authorization",
+												"value": "Bearer {{Split_API_Token}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"url": {
+											"raw": "{{Split_API_Base_URL}}/users/{{Split_User_Identifier}}",
+											"host": [
+												"{{Split_API_Base_URL}}"
+											],
+											"path": [
+												"users",
+												"{{Split_User_Identifier}}"
+											],
+											"variable": [
+												{
+													"key": "Split User Identifier",
+													"value": "abc123"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Authorization",
+											"value": "Bearer {{Split_API_Token}}",
+											"description": ""
+										}
+									],
+									"cookie": [],
+									"body": "{\n  \"id\": \"abc123\",\n  \"email\": \"user@example.com\",\n  \"name\": \"Jane Doe\",\n  \"state\": \"ACTIVE\",\n  \"groups\": [\n    {\n      \"id\": \"group1\",\n      \"name\": \"Admins\"\n    }\n  ],\n  \"createdAt\": \"2023-01-01T12:00:00Z\",\n  \"updatedAt\": \"2023-06-01T12:00:00Z\"\n}"
+								}
+							]
 						},
 						{
 							"name": "Update User",
@@ -99,17 +198,68 @@
 									}
 								},
 								"url": {
-									"raw": "{{Split API Base URL}}/users/{{Split User Identifier}}",
+									"raw": "{{Split_API_Base_URL}}/users/{{Split_User_Identifier}}",
 									"host": [
-										"{{Split API Base URL}}"
+										"{{Split_API_Base_URL}}"
 									],
 									"path": [
 										"users",
-										"{{Split User Identifier}}"
+										"{{Split_User_Identifier}}"
 									]
-								}
+								},
+								"description": "**Legacy Split API doc link:** [https://docs.split.io/reference/full-update-user](https://docs.split.io/reference/full-update-user)"
 							},
-							"response": []
+							"response": [
+								{
+									"name": "Successful User Update",
+									"originalRequest": {
+										"method": "PUT",
+										"header": [
+											{
+												"key": "content",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n    \"name\": \"updated user name\"\n    // \"email\": \"<email>\",\n    // \"2fa\":false,\n    // \"status\":\"ACTIVE\"\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{Split_API_Base_URL}}/users/{{Split_User_Identifier}}",
+											"host": [
+												"{{Split_API_Base_URL}}"
+											],
+											"path": [
+												"users",
+												"{{Split_User_Identifier}}"
+											],
+											"variable": [
+												{
+													"key": "Split User Identifier",
+													"value": "{{Split_API_Base_URL}}"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "content",
+											"value": "application/json",
+											"description": ""
+										}
+									],
+									"cookie": [],
+									"body": "{\n  \"id\": \"{{Split_User_Identifier}}\",\n  \"name\": \"updated user name\",\n  \"email\": \"user@example.com\",\n  \"2fa\": false,\n  \"status\": \"ACTIVE\",\n  \"groups\": [\"group-1\", \"group-2\"],\n  \"updatedAt\": \"2024-06-01T12:00:00Z\"\n}"
+								}
+							]
 						},
 						{
 							"name": "Delete a Pending User",
@@ -117,23 +267,52 @@
 								"method": "DELETE",
 								"header": [],
 								"url": {
-									"raw": "{{Split API Base URL}}/users/:userId",
+									"raw": "{{Split_API_Base_URL}}/users/{{Split_Pending_User_Identifier}}",
 									"host": [
-										"{{Split API Base URL}}"
+										"{{Split_API_Base_URL}}"
 									],
 									"path": [
 										"users",
-										":userId"
-									],
-									"variable": [
-										{
-											"key": "userId",
-											"value": ""
-										}
+										"{{Split_Pending_User_Identifier}}"
 									]
-								}
+								},
+								"description": "**Legacy Split API doc link:** [https://docs.split.io/reference/delete-a-pending-user](https://docs.split.io/reference/delete-a-pending-user)"
 							},
-							"response": []
+							"response": [
+								{
+									"name": "204 No Content - Pending user deleted",
+									"originalRequest": {
+										"method": "DELETE",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"url": {
+											"raw": "{{Split_API_Base_URL}}/users/:userId",
+											"host": [
+												"{{Split_API_Base_URL}}"
+											],
+											"path": [
+												"users",
+												":userId"
+											],
+											"variable": [
+												{
+													"key": "userId",
+													"value": "user_abc123"
+												}
+											]
+										}
+									},
+									"status": "No Content",
+									"code": 204,
+									"_postman_previewlanguage": "json",
+									"header": [],
+									"cookie": [],
+									"body": "{}"
+								}
+							]
 						},
 						{
 							"name": "Add User to Group",
@@ -143,7 +322,7 @@
 									"bearer": [
 										{
 											"key": "token",
-											"value": "{{Split API Token}}",
+											"value": "{{Split_API_Token}}",
 											"type": "string"
 										}
 									]
@@ -158,20 +337,61 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "[\n    {\n        \"op\": \"add\",\n        \"path\": \"/groups/0\",\n        \"value\": {\n            \"id\": \"{{Split Group Identifier}}\",\n            \"type\": \"group\"\n        }\n    }\n]"
+									"raw": "[\n    {\n        \"op\": \"add\",\n        \"path\": \"/groups/0\",\n        \"value\": {\n            \"id\": \"{{Split_Group_Identifier}}\",\n            \"type\": \"group\"\n        }\n    }\n]"
 								},
 								"url": {
-									"raw": "{{Split API Base URL}}/users/{{Split User Identifier}}",
+									"raw": "{{Split_API_Base_URL}}/users/{{Split_User_Identifier}}",
 									"host": [
-										"{{Split API Base URL}}"
+										"{{Split_API_Base_URL}}"
 									],
 									"path": [
 										"users",
-										"{{Split User Identifier}}"
+										"{{Split_User_Identifier}}"
 									]
-								}
+								},
+								"description": "**Legacy Split API doc link:** [https://docs.split.io/reference/update-users-groups](https://docs.split.io/reference/update-users-groups)"
 							},
-							"response": []
+							"response": [
+								{
+									"name": "Add User to Group",
+									"originalRequest": {
+										"method": "PATCH",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json",
+												"type": "text"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "[\n    {\n        \"op\": \"add\",\n        \"path\": \"/groups/0\",\n        \"value\": {\n            \"id\": \"{{Split_Group_Identifier}}\",\n            \"type\": \"group\"\n        }\n    }\n]"
+										},
+										"url": {
+											"raw": "{{Split_API_Base_URL}}/users/{{Split_User_Identifier}}",
+											"host": [
+												"{{Split_API_Base_URL}}"
+											],
+											"path": [
+												"users",
+												"{{Split_User_Identifier}}"
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "",
+									"header": [],
+									"cookie": [
+										{
+											"expires": "Invalid Date",
+											"domain": "",
+											"path": ""
+										}
+									],
+									"body": "{\n  \"id\": \"<group_id>\",\n  \"name\": \"<group_name>\",\n  \"description\": \"<description>\",\n  \"type\": \"group\"\n}"
+								}
+							]
 						},
 						{
 							"name": "Remove User from Group",
@@ -181,7 +401,7 @@
 									"bearer": [
 										{
 											"key": "token",
-											"value": "{{Split API Token}}",
+											"value": "{{Split_API_Token}}",
 											"type": "string"
 										}
 									]
@@ -196,20 +416,60 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "[\n    {\n        \"op\": \"remove\",\n        \"path\": \"/groups/0\",\n        \"value\": {\n            \"id\": \"{{Split Group Identifier}}\",\n            \"type\": \"group\"\n        }\n    }\n]"
+									"raw": "[\n    {\n        \"op\": \"remove\",\n        \"path\": \"/groups/0\",\n        \"value\": {\n            \"id\": \"{{Split_Group_Identifier}}\",\n            \"type\": \"group\"\n        }\n    }\n]"
 								},
 								"url": {
-									"raw": "{{Split API Base URL}}/users/{{Split User Identifier}}",
+									"raw": "{{Split_API_Base_URL}}/users/{{Split_User_Identifier}}",
 									"host": [
-										"{{Split API Base URL}}"
+										"{{Split_API_Base_URL}}"
 									],
 									"path": [
 										"users",
-										"{{Split User Identifier}}"
+										"{{Split_User_Identifier}}"
 									]
-								}
+								},
+								"description": "**Legacy Split API doc link:** [https://docs.split.io/reference/update-users-groups](https://docs.split.io/reference/update-users-groups)"
 							},
-							"response": []
+							"response": [
+								{
+									"name": "Successful removal of user from group",
+									"originalRequest": {
+										"method": "PATCH",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "[\n    {\n        \"op\": \"remove\",\n        \"path\": \"/groups/0\",\n        \"value\": {\n            \"id\": \"{{Split_Group_Identifier}}\",\n            \"type\": \"group\"\n        }\n    }\n]"
+										},
+										"url": {
+											"raw": "{{Split_API_Base_URL}}/users/{{Split_User_Identifier}}",
+											"host": [
+												"{{Split_API_Base_URL}}"
+											],
+											"path": [
+												"users",
+												"{{Split_User_Identifier}}"
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json",
+											"description": ""
+										}
+									],
+									"cookie": [],
+									"body": "{\n  \"id\": \"{{Split_User_Identifier}}\",\n  \"groups\": [\n    // List of group objects after removal, e.g.,\n    // { \"id\": \"group-123\", \"type\": \"group\" }\n  ],\n  \"message\": \"User removed from group successfully.\"\n}"
+								}
+							]
 						},
 						{
 							"name": "Invite a new User",
@@ -221,16 +481,92 @@
 									"raw": "{\n  \"email\": \"<email>\",\n  \"groups\": [\n    {\n      \"id\": \"<groupId>\",\n      \"type\": \"group\"\n    }\n  ]\n}"
 								},
 								"url": {
-									"raw": "{{Split API Base URL}}/users",
+									"raw": "{{Split_API_Base_URL}}/users",
 									"host": [
-										"{{Split API Base URL}}"
+										"{{Split_API_Base_URL}}"
 									],
 									"path": [
 										"users"
 									]
-								}
+								},
+								"description": "**Legacy Split API doc link:** [https://docs.split.io/reference/invite-a-new-user](https://docs.split.io/reference/invite-a-new-user)"
 							},
-							"response": []
+							"response": [
+								{
+									"name": "201 Created - User invited",
+									"originalRequest": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n  \"email\": \"invited.user@example.com\",\n  \"groups\": [\n    {\n      \"id\": \"group1\",\n      \"type\": \"group\"\n    }\n  ]\n}"
+										},
+										"url": {
+											"raw": "{{Split_API_Base_URL}}/users",
+											"host": [
+												"{{Split_API_Base_URL}}"
+											],
+											"path": [
+												"users"
+											]
+										}
+									},
+									"status": "Created",
+									"code": 201,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json",
+											"description": ""
+										}
+									],
+									"cookie": [],
+									"body": "{\n  \"id\": \"user_abc123\",\n  \"email\": \"invited.user@example.com\",\n  \"status\": \"PENDING\",\n  \"groups\": [\n    {\n      \"id\": \"group1\",\n      \"type\": \"group\"\n    }\n  ],\n  \"invitedAt\": \"2024-06-01T12:00:00Z\"\n}"
+								},
+								{
+									"name": "Successful User Invitation (201 Created)",
+									"originalRequest": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n  \"email\": \"invited.user@example.com\",\n  \"role\": \"member\"\n}",
+											"options": {
+												"raw": "json"
+											}
+										},
+										"url": {
+											"raw": "/users",
+											"path": [
+												"users"
+											]
+										}
+									},
+									"status": "Created",
+									"code": 201,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json",
+											"description": ""
+										}
+									],
+									"cookie": [],
+									"body": "{\n  \"userId\": \"12345\",\n  \"email\": \"invited.user@example.com\",\n  \"status\": \"invited\",\n  \"invitedAt\": \"2024-06-10T12:34:56Z\",\n  \"role\": \"member\",\n  \"requestId\": \"req-67890\"\n}"
+								}
+							]
 						}
 					],
 					"description": "The `/users` endpoint becomes unavailable to you once your account has been migrated to Harness.\n\nSee the overview in the Users folder above this one for a side-by-side comparison of how users are managed in Split vs Harness.\n\n### Deleting and Disabling Users\n\n- Split supports the deletion of pending users only.\n    \n- Split supports a disabled user state. Harness does not.\n    \n\n### Group Membership: Managed by This Endpoint\n\nIn addition to **CRUD operations on users**, this endpoint is where **group membership** **operations** are performed in Split. For that reason, you will find these group-related examples here under Users, instead of in the Groups folder:\n\n- List Users (optionally takes group as filter)\n    \n- Add User to Group\n    \n- Remove User from Group",
@@ -239,7 +575,7 @@
 						"bearer": [
 							{
 								"key": "token",
-								"value": "{{Split API Token}}",
+								"value": "{{Split_API_Token}}",
 								"type": "string"
 							}
 						]
@@ -277,7 +613,7 @@
 								"header": [
 									{
 										"key": "x-api-key",
-										"value": "{{Harness API Token}}",
+										"value": "{{Harness_API_Token}}",
 										"type": "text"
 									},
 									{
@@ -287,9 +623,9 @@
 									}
 								],
 								"url": {
-									"raw": "{{Harness API Base URL}}/user/aggregate?accountIdentifier={{Harness Account Identifier}}&searchTerm=",
+									"raw": "{{Harness_API_Base_URL}}/user/aggregate?accountIdentifier={{Harness_Account_Identifier}}&searchTerm=",
 									"host": [
-										"{{Harness API Base URL}}"
+										"{{Harness_API_Base_URL}}"
 									],
 									"path": [
 										"user",
@@ -298,7 +634,7 @@
 									"query": [
 										{
 											"key": "accountIdentifier",
-											"value": "{{Harness Account Identifier}}"
+											"value": "{{Harness_Account_Identifier}}"
 										},
 										{
 											"key": "searchTerm",
@@ -306,9 +642,54 @@
 										}
 									]
 								},
-								"description": "Doc link: [https://apidocs.harness.io/tag/User#operation/getAggregatedUsers](https://apidocs.harness.io/tag/User#operation/getAggregatedUsers)"
+								"description": "**Harness API doc link:** [https://apidocs.harness.io/user/getaggregatedusers](https://apidocs.harness.io/user/getaggregatedusers)"
 							},
-							"response": []
+							"response": [
+								{
+									"name": "200 OK - Get List of Users Example",
+									"originalRequest": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "x-api-key",
+												"value": "{{Harness_API_Token}}",
+												"type": "text"
+											},
+											{
+												"key": "Content-Type",
+												"value": "application/json",
+												"type": "text"
+											}
+										],
+										"url": {
+											"raw": "{{Harness_API_Base_URL}}/user/aggregate?accountIdentifier={{Harness Account Identifier}}&searchTerm=",
+											"host": [
+												"{{Harness_API_Base_URL}}"
+											],
+											"path": [
+												"user",
+												"aggregate"
+											],
+											"query": [
+												{
+													"key": "accountIdentifier",
+													"value": "{{Harness Account Identifier}}"
+												},
+												{
+													"key": "searchTerm",
+													"value": ""
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": null,
+									"header": null,
+									"cookie": [],
+									"body": "{\n  \"status\": \"SUCCESS\",\n  \"data\": {\n    \"totalPages\": 0,\n    \"totalItems\": 0,\n    \"pageItemCount\": 0,\n    \"pageSize\": 0,\n    \"content\": [ … ],\n    \"pageIndex\": 0,\n    \"empty\": true,\n    \"pageToken\": \"string\"\n  },\n  \"metaData\": {},\n  \"correlationId\": \"string\"\n}"
+								}
+							]
 						},
 						{
 							"name": "Get User",
@@ -317,7 +698,7 @@
 								"header": [
 									{
 										"key": "x-api-key",
-										"value": "{{Harness API Token}}",
+										"value": "{{Harness_API_Token}}",
 										"type": "text"
 									},
 									{
@@ -327,25 +708,82 @@
 									}
 								],
 								"url": {
-									"raw": "{{Harness API Base URL}}/user/aggregate/{{Harness User Identifier}}?accountIdentifier={{Harness Account Identifier}}",
+									"raw": "{{Harness_API_Base_URL}}/user/aggregate/{{Harness_User_Identifier}}?accountIdentifier={{Harness_Account_Identifier}}",
 									"host": [
-										"{{Harness API Base URL}}"
+										"{{Harness_API_Base_URL}}"
 									],
 									"path": [
 										"user",
 										"aggregate",
-										"{{Harness User Identifier}}"
+										"{{Harness_User_Identifier}}"
 									],
 									"query": [
 										{
 											"key": "accountIdentifier",
-											"value": "{{Harness Account Identifier}}"
+											"value": "{{Harness_Account_Identifier}}"
 										}
 									]
 								},
-								"description": "Docs link: [https://apidocs.harness.io/tag/User#operation/getAggregatedUser](https://apidocs.harness.io/tag/User#operation/getAggregatedUser)"
+								"description": "**Harness API doc link:** [https://apidocs.harness.io/user/getaggregateduser](https://apidocs.harness.io/user/getaggregateduser)"
 							},
-							"response": []
+							"response": [
+								{
+									"name": "Successful User Retrieval",
+									"originalRequest": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "x-api-key",
+												"value": "{{Harness_API_Token}}"
+											},
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											}
+										],
+										"url": {
+											"raw": "{{Harness_API_Base_URL}}/user/aggregate/{{Harness_User_Identifier}}?accountIdentifier={{Harness_Account_Identifier}}",
+											"host": [
+												"{{Harness_API_Base_URL}}"
+											],
+											"path": [
+												"user",
+												"aggregate",
+												"{{Harness_User_Identifier}}"
+											],
+											"query": [
+												{
+													"key": "accountIdentifier",
+													"value": "{{Harness Account Identifier}}"
+												}
+											],
+											"variable": [
+												{
+													"key": "Harness User Identifier",
+													"value": "{{Harness_User_Identifier}}"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "x-api-key",
+											"value": "{{Harness_API_Token}}",
+											"description": ""
+										},
+										{
+											"key": "Content-Type",
+											"value": "application/json",
+											"description": ""
+										}
+									],
+									"cookie": [],
+									"body": "{\n  \"user\": {\n    \"id\": \"{{Harness_User_Identifier}}\",\n    \"email\": \"user@example.com\",\n    \"name\": \"Jane Doe\",\n    \"groups\": [\n      \"EnablementGroup\"\n    ],\n    \"roles\": [\n      \"project_viewer\"\n    ],\n    \"status\": \"ACTIVE\"\n  }\n}"
+								}
+							]
 						},
 						{
 							"name": "Update User",
@@ -354,7 +792,7 @@
 								"header": [
 									{
 										"key": "x-api-key",
-										"value": "{{Harness API Token}}",
+										"value": "{{Harness_API_Token}}",
 										"type": "text"
 									}
 								],
@@ -368,9 +806,9 @@
 									}
 								},
 								"url": {
-									"raw": "{{Harness API Base URL}}/user?accountIdentifier={{Harness Account Identifier}}",
+									"raw": "{{Harness_API_Base_URL}}/user?accountIdentifier={{Harness Account Identifier}}",
 									"host": [
-										"{{Harness API Base URL}}"
+										"{{Harness_API_Base_URL}}"
 									],
 									"path": [
 										"user"
@@ -381,9 +819,59 @@
 											"value": "{{Harness Account Identifier}}"
 										}
 									]
-								}
+								},
+								"description": "**Harness API doc link:** [https://apidocs.harness.io/user/updateuserinfo](https://apidocs.harness.io/user/updateuserinfo)"
 							},
-							"response": []
+							"response": [
+								{
+									"name": "Successful User Update (200 OK)",
+									"originalRequest": {
+										"method": "PUT",
+										"header": [
+											{
+												"key": "x-api-key",
+												"value": "{{Harness_API_Token}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n    \"uuid\": \"wtW6nhcYS5KqUqEeekMtuA\",\n    \"name\": \"Johannes Liegl\",\n    \"email\": \"johannes.liegl+demo@harness.io\"\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{Harness_API_Base_URL}}/user?accountIdentifier={{Harness_Account_Identifier}}",
+											"host": [
+												"{{Harness_API_Base_URL}}"
+											],
+											"path": [
+												"user"
+											],
+											"query": [
+												{
+													"key": "accountIdentifier",
+													"value": "{{Harness Account Identifier}}"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "x-api-key",
+											"value": "{{Harness_API_Token}}",
+											"description": ""
+										}
+									],
+									"cookie": [],
+									"body": "{\n  \"resource\": {\n    \"uuid\": \"wtW6nhcYS5KqUqEeekMtuA\",\n    \"name\": \"Johannes Liegl\",\n    \"email\": \"johannes.liegl+demo@harness.io\",\n    \"locked\": false,\n    \"disabled\": false,\n    \"external\": false,\n    \"createdAt\": 1700000000000,\n    \"updatedAt\": 1700000001000\n  },\n  \"created\": false,\n  \"updated\": true,\n  \"metaData\": null,\n  \"correlationId\": \"string\"\n}"
+								}
+							]
 						},
 						{
 							"name": "Add User to Group",
@@ -392,7 +880,7 @@
 								"header": [
 									{
 										"key": "x-api-key",
-										"value": "{{Harness API Token}}",
+										"value": "{{Harness_API_Token}}",
 										"type": "text"
 									}
 								],
@@ -406,25 +894,82 @@
 									}
 								},
 								"url": {
-									"raw": "{{Harness API Base URL}}/user/add-user-to-groups/{{Harness User Identifier}}?accountIdentifier={{Harness Account Identifier}}",
+									"raw": "{{Harness_API_Base_URL}}/user/add-user-to-groups/{{Harness_User_Identifier}}?accountIdentifier={{Harness_Account_Identifier}}",
 									"host": [
-										"{{Harness API Base URL}}"
+										"{{Harness_API_Base_URL}}"
 									],
 									"path": [
 										"user",
 										"add-user-to-groups",
-										"{{Harness User Identifier}}"
+										"{{Harness_User_Identifier}}"
 									],
 									"query": [
 										{
 											"key": "accountIdentifier",
-											"value": "{{Harness Account Identifier}}"
+											"value": "{{Harness_Account_Identifier}}"
 										}
 									]
 								},
-								"description": "Docs link: [https://apidocs.harness.io/tag/User#operation/addUserToUserGroups](https://apidocs.harness.io/tag/User#operation/addUserToUserGroups)"
+								"description": "**Harness API doc link:** [https://apidocs.harness.io/user/addusertousergroups](https://apidocs.harness.io/user/addusertousergroups)"
 							},
-							"response": []
+							"response": [
+								{
+									"name": "Successful User Added to Group",
+									"originalRequest": {
+										"method": "PUT",
+										"header": [
+											{
+												"key": "x-api-key",
+												"value": "{{Harness_API_Token}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n    \"userGroupIdsToAdd\": [\n        \"EnablementGroup\"\n    ]\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{Harness_API_Base_URL}}/user/add-user-to-groups/{{Harness_User_Identifier}}?accountIdentifier={{Harness_Account_Identifier}}",
+											"host": [
+												"{{Harness_API_Base_URL}}"
+											],
+											"path": [
+												"user",
+												"add-user-to-groups",
+												"{{Harness_User_Identifier}}"
+											],
+											"query": [
+												{
+													"key": "accountIdentifier",
+													"value": "{{Harness Account Identifier}}"
+												}
+											],
+											"variable": [
+												{
+													"key": "Harness User Identifier",
+													"value": "{{Harness_User_Identifier}}"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "x-api-key",
+											"value": "{{Harness_API_Token}}",
+											"description": ""
+										}
+									],
+									"cookie": [],
+									"body": "{\n  \"status\": \"SUCCESS\",\n  \"message\": \"User added to group(s) successfully.\",\n  \"userId\": \"{{Harness_User_Identifier}}\",\n  \"groupsAdded\": [\n    \"EnablementGroup\"\n  ]\n}"
+								}
+							]
 						},
 						{
 							"name": "Invite a New User",
@@ -433,7 +978,7 @@
 								"header": [
 									{
 										"key": "x-api-key",
-										"value": "{{Harness API Token}}",
+										"value": "{{Harness_API_Token}}",
 										"type": "text"
 									}
 								],
@@ -447,9 +992,9 @@
 									}
 								},
 								"url": {
-									"raw": "{{Harness API Base URL}}/user/users?accountIdentifier={{Harness Account Identifier}}",
+									"raw": "{{Harness_API_Base_URL}}/user/users?accountIdentifier={{Harness_Account_Identifier}}",
 									"host": [
-										"{{Harness API Base URL}}"
+										"{{Harness_API_Base_URL}}"
 									],
 									"path": [
 										"user",
@@ -458,13 +1003,63 @@
 									"query": [
 										{
 											"key": "accountIdentifier",
-											"value": "{{Harness Account Identifier}}"
+											"value": "{{Harness_Account_Identifier}}"
 										}
 									]
 								},
-								"description": "Docs link: [https://apidocs.harness.io/tag/User#operation/addUsers](https://apidocs.harness.io/tag/User#operation/addUsers)"
+								"description": "**Harness API doc link:** [https://apidocs.harness.io/user/addusers](https://apidocs.harness.io/user/addusers)"
 							},
-							"response": []
+							"response": [
+								{
+									"name": "Successful User Invitation (201 Created)",
+									"originalRequest": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "x-api-key",
+												"value": "{{Harness_API_Token}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n    \"emails\": [\n        \"david.karow+enablement@harness.io\"\n    ],\n    \"roleBindings\": [\n        {\n            \"roleIdentifier\": \"_fme_manager\",\n            \"roleName\": \"Split FME Manager Role\",\n            \"roleScopeLevel\": \"account\",\n            \"resourceGroupIdentifier\": \"_all_resources_including_child_scopes\",\n            \"resourceGroupName\": \"All Resources Including Child Scopes\",\n            \"managedRole\": true,\n            \"managedRoleAssignment\": false\n        },\n        {\n            \"roleIdentifier\": \"_fme_administrator\",\n            \"roleName\": \"Split FME Administrator Role\",\n            \"roleScopeLevel\": \"account\",\n            \"resourceGroupIdentifier\": \"_all_resources_including_child_scopes\",\n            \"resourceGroupName\": \"All Resources Including Child Scopes\",\n            \"managedRole\": true,\n            \"managedRoleAssignment\": false\n        }\n    ]\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{Harness_API_Base_URL}}/user/users?accountIdentifier={{Harness_Account_Identifier}}",
+											"host": [
+												"{{Harness_API_Base_URL}}"
+											],
+											"path": [
+												"user",
+												"users"
+											],
+											"query": [
+												{
+													"key": "accountIdentifier",
+													"value": "{{Harness Account Identifier}}"
+												}
+											]
+										}
+									},
+									"status": "Created",
+									"code": 201,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "x-api-key",
+											"value": "{{Harness_API_Token}}",
+											"description": ""
+										}
+									],
+									"cookie": [],
+									"body": "{\n  \"resource\": [\n    {\n      \"email\": \"david.karow+enablement@harness.io\",\n      \"userGroupIds\": [],\n      \"roleBindings\": [\n        {\n          \"roleIdentifier\": \"_fme_manager\",\n          \"roleName\": \"Split FME Manager Role\",\n          \"roleScopeLevel\": \"account\",\n          \"resourceGroupIdentifier\": \"_all_resources_including_child_scopes\",\n          \"resourceGroupName\": \"All Resources Including Child Scopes\",\n          \"managedRole\": true,\n          \"managedRoleAssignment\": false\n        },\n        {\n          \"roleIdentifier\": \"_fme_administrator\",\n          \"roleName\": \"Split FME Administrator Role\",\n          \"roleScopeLevel\": \"account\",\n          \"resourceGroupIdentifier\": \"_all_resources_including_child_scopes\",\n          \"resourceGroupName\": \"All Resources Including Child Scopes\",\n          \"managedRole\": true,\n          \"managedRoleAssignment\": false\n        }\n      ],\n      \"status\": \"INVITED\"\n    }\n  ],\n  \"responseMessages\": [\n    {\n      \"code\": \"USER_INVITED_SUCCESSFULLY\",\n      \"level\": \"INFO\",\n      \"message\": \"User(s) invited successfully.\"\n    }\n  ]\n}"
+								}
+							]
 						},
 						{
 							"name": "Delete Pending User",
@@ -473,29 +1068,80 @@
 								"header": [
 									{
 										"key": "x-api-key",
-										"value": "{{Harness API Token}}",
+										"value": "{{Harness_API_Token}}",
 										"type": "text"
 									}
 								],
 								"url": {
-									"raw": "{{Harness API Base URL}}/invites/{{Harness Invite Identifier}}?accountIdentifier={{Harness Account Identifier}}",
+									"raw": "{{Harness_API_Base_URL}}/invites/{{Harness_Invite_Identifier}}?accountIdentifier={{Harness_Account_Identifier}}",
 									"host": [
-										"{{Harness API Base URL}}"
+										"{{Harness_API_Base_URL}}"
 									],
 									"path": [
 										"invites",
-										"{{Harness Invite Identifier}}"
+										"{{Harness_Invite_Identifier}}"
 									],
 									"query": [
 										{
 											"key": "accountIdentifier",
-											"value": "{{Harness Account Identifier}}"
+											"value": "{{Harness_Account_Identifier}}"
 										}
 									]
 								},
-								"description": "Docs link: [https://apidocs.harness.io/tag/Invite#operation/deleteInvite](https://apidocs.harness.io/tag/Invite#operation/deleteInvite)"
+								"description": "**Harness API doc link:** [https://apidocs.harness.io/invite/deleteinvite](https://apidocs.harness.io/invite/deleteinvite)"
 							},
-							"response": []
+							"response": [
+								{
+									"name": "204 No Content - Pending User Deleted",
+									"originalRequest": {
+										"method": "DELETE",
+										"header": [
+											{
+												"key": "x-api-key",
+												"value": "{{Harness_API_Token}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"url": {
+											"raw": "{{Harness_API_Base_URL}}/invites/{{Harness_Invite_Identifier}}?accountIdentifier={{Harness_Account_Identifier}}",
+											"host": [
+												"{{Harness_API_Base_URL}}"
+											],
+											"path": [
+												"invites",
+												"{{Harness_Invite_Identifier}}"
+											],
+											"query": [
+												{
+													"key": "accountIdentifier",
+													"value": "{{Harness Account Identifier}}"
+												}
+											],
+											"variable": [
+												{
+													"key": "Harness Invite Identifier",
+													"value": "<invite_id>"
+												}
+											]
+										}
+									},
+									"status": "No Content",
+									"code": 204,
+									"_postman_previewlanguage": "text",
+									"header": [
+										{
+											"key": "x-api-key",
+											"value": "{{Harness_API_Token}}",
+											"description": ""
+										}
+									],
+									"cookie": [],
+									"body": "No content is returned when a pending user is successfully deleted."
+								}
+							]
 						},
 						{
 							"name": "List Pending Users",
@@ -504,14 +1150,14 @@
 								"header": [
 									{
 										"key": "x-api-key",
-										"value": "{{Harness API Token}}",
+										"value": "{{Harness_API_Token}}",
 										"type": "text"
 									}
 								],
 								"url": {
-									"raw": "{{Harness API Base URL}}/invites/aggregate?accountIdentifier={{Harness Account Identifier}}",
+									"raw": "{{Harness_API_Base_URL}}/invites/aggregate?accountIdentifier={{Harness_Account_Identifier}}",
 									"host": [
-										"{{Harness API Base URL}}"
+										"{{Harness_API_Base_URL}}"
 									],
 									"path": [
 										"invites",
@@ -520,13 +1166,58 @@
 									"query": [
 										{
 											"key": "accountIdentifier",
-											"value": "{{Harness Account Identifier}}"
+											"value": "{{Harness_Account_Identifier}}"
 										}
 									]
 								},
-								"description": "Docs link for \"Get pending users\": [https://apidocs.harness.io/tag/Invite#operation/getPendingUsersAggregated](https://apidocs.harness.io/tag/Invite#operation/getPendingUsersAggregated)\n\nSee also docs for the \"List Invites\" endpoint: [https://apidocs.harness.io/tag/Invite#operation/getInvites](https://apidocs.harness.io/tag/Invite#operation/getInvites)"
+								"description": "**Harness API doc link - Get pending users:** [https://apidocs.harness.io/invite/getpendingusersaggregated](https://apidocs.harness.io/invite/getpendingusersaggregated)\n\nSee also:\n\n**Harness API doc link - List Invites:** [https://apidocs.harness.io/invite/getinvites](https://apidocs.harness.io/invite/getinvites)"
 							},
-							"response": []
+							"response": [
+								{
+									"name": "200 OK - List of Pending Users",
+									"originalRequest": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "x-api-key",
+												"value": "{{Harness_API_Token}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"url": {
+											"raw": "{{Harness_API_Base_URL}}/invites/aggregate?accountIdentifier={{Harness_Account_Identifier}}",
+											"host": [
+												"{{Harness_API_Base_URL}}"
+											],
+											"path": [
+												"invites",
+												"aggregate"
+											],
+											"query": [
+												{
+													"key": "accountIdentifier",
+													"value": "{{Harness Account Identifier}}"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "x-api-key",
+											"value": "{{Harness_API_Token}}",
+											"description": ""
+										}
+									],
+									"cookie": [],
+									"body": "{\n  \"resource\": [\n    {\n      \"email\": \"pending.user1@example.com\",\n      \"name\": \"Pending User One\",\n      \"roleBindings\": [\n        {\n          \"role\": \"project_viewer\",\n          \"resourceGroup\": \"project:12345\"\n        }\n      ],\n      \"invitedBy\": \"admin@example.com\",\n      \"invitedAt\": \"2024-06-01T12:34:56Z\",\n      \"status\": \"PENDING\"\n    },\n    {\n      \"email\": \"pending.user2@example.com\",\n      \"name\": \"Pending User Two\",\n      \"roleBindings\": [\n        {\n          \"role\": \"fme_manager\",\n          \"resourceGroup\": \"account:67890\"\n        }\n      ],\n      \"invitedBy\": \"admin@example.com\",\n      \"invitedAt\": \"2024-06-02T09:21:00Z\",\n      \"status\": \"PENDING\"\n    }\n  ],\n  \"metaData\": {\n    \"total\": 2,\n    \"page\": 0,\n    \"limit\": 50\n  }\n}"
+								}
+							]
 						}
 					],
 					"description": "The `/user` and `/invites` endpoints here replace the Split `/users` endpoint after migration.\n\nSee the overview in the Users folder above this one for a side-by-side comparison of how users are managed in Split vs Harness.\n\n### Deleting and Disabling Users\n\n- Harness supports the deletion of pending and active users.\n    \n- Harness does not support a disabled user state because of conflicts that can create with different SCIM providers",
@@ -535,7 +1226,7 @@
 						"apikey": [
 							{
 								"key": "value",
-								"value": "{{Harness API Token}}",
+								"value": "{{Harness_API_Token}}",
 								"type": "string"
 							},
 							{
@@ -583,17 +1274,47 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "{{Split API Base URL}}/groups",
+									"raw": "{{Split_API_Base_URL}}/groups",
 									"host": [
-										"{{Split API Base URL}}"
+										"{{Split_API_Base_URL}}"
 									],
 									"path": [
 										"groups"
 									]
 								},
-								"description": "List all active groups in the organization."
+								"description": "List all active groups in the organization.\n\n**Legacy Split API doc link:** [https://docs.split.io/reference/list-groups](https://docs.split.io/reference/list-groups)"
 							},
-							"response": []
+							"response": [
+								{
+									"name": "200 OK - List Groups Example",
+									"originalRequest": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{Split_API_Base_URL}}/groups",
+											"host": [
+												"{{Split_API_Base_URL}}"
+											],
+											"path": [
+												"groups"
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json",
+											"description": "",
+											"type": "text"
+										}
+									],
+									"cookie": [],
+									"body": "{\n    \"objects\": [\n        {\n            \"id\": \"12345678-1234-1234-1234-1234567890ab\",\n            \"name\": \"Administrators\",\n            \"description\": \"Grants access to advanced administrative features\",\n            \"type\": \"group\"\n        },\n        {\n            \"id\": \"12345678-1234-1234-1234-1234567890cd\",\n            \"name\": \"Engineering\",\n            \"description\": \"\",\n            \"type\": \"group\"\n        }\n    ],\n    \"offset\": 0,\n    \"limit\": 50,\n    \"totalCount\": 2\n}"
+								}
+							]
 						},
 						{
 							"name": "Get Group",
@@ -601,17 +1322,136 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "{{Split API Base URL}}/groups/{{Split Group Identifier}}",
+									"raw": "{{Split_API_Base_URL}}/groups/{{Split_Group_Identifier}}",
 									"host": [
-										"{{Split API Base URL}}"
+										"{{Split_API_Base_URL}}"
 									],
 									"path": [
 										"groups",
-										"{{Split Group Identifier}}"
+										"{{Split_Group_Identifier}}"
 									]
-								}
+								},
+								"description": "**Legacy Split API doc link:** [https://docs.split.io/reference/get-group](https://docs.split.io/reference/get-group)"
 							},
-							"response": []
+							"response": [
+								{
+									"name": "Successful Group Retrieval",
+									"originalRequest": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"url": {
+											"raw": "{{Split_API_Base_URL}}/groups/{{Split_Group_Identifier}}",
+											"host": [
+												"{{Split_API_Base_URL}}"
+											],
+											"path": [
+												"groups",
+												"{{Split_Group_Identifier}}"
+											],
+											"variable": [
+												{
+													"key": "Split Group Identifier",
+													"value": "{{Split_Group_Identifier}}"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json",
+											"description": ""
+										}
+									],
+									"cookie": [],
+									"body": "{\n  \"id\": \"{{Split_Group_Identifier}}\",\n  \"name\": \"Example Group Name\",\n  \"description\": \"Example group description.\",\n  \"createdAt\": \"2024-06-01T12:00:00Z\",\n  \"updatedAt\": \"2024-06-01T12:00:00Z\"\n}"
+								},
+								{
+									"name": "200 OK - Group details returned successfully",
+									"originalRequest": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "Authorization",
+												"value": "Bearer <API_KEY>"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"url": {
+											"raw": "{{Split_API_Base_URL}}/groups/{{Split_Group_Identifier}}",
+											"host": [
+												"{{Split_API_Base_URL}}"
+											],
+											"path": [
+												"groups",
+												"{{Split_Group_Identifier}}"
+											],
+											"variable": [
+												{
+													"key": "Split Group Identifier",
+													"value": "grp_12345"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Authorization",
+											"value": "Bearer <API_KEY>",
+											"description": ""
+										}
+									],
+									"cookie": [],
+									"body": "{\n  \"id\": \"grp_12345\",\n  \"name\": \"Engineering\",\n  \"description\": \"Engineering team group\",\n  \"createdAt\": \"2023-01-01T12:00:00Z\",\n  \"updatedAt\": \"2023-06-01T15:30:00Z\",\n  \"users\": [\n    {\n      \"id\": \"user_001\",\n      \"name\": \"Alice Smith\",\n      \"email\": \"alice.smith@example.com\"\n    },\n    {\n      \"id\": \"user_002\",\n      \"name\": \"Bob Jones\",\n      \"email\": \"bob.jones@example.com\"\n    }\n  ]\n}"
+								},
+								{
+									"name": "Successful Group Retrieval",
+									"originalRequest": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{Split_API_Base_URL}}/groups/{{Split_Group_Identifier}}",
+											"host": [
+												"{{Split_API_Base_URL}}"
+											],
+											"path": [
+												"groups",
+												"{{Split_Group_Identifier}}"
+											],
+											"variable": [
+												{
+													"key": "Split Group Identifier",
+													"value": "theEnGroup"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [],
+									"cookie": [],
+									"body": "{\n  \"id\": \"theEnGroup\",\n  \"name\": \"the enablement group\",\n  \"description\": \"A group for enablement users.\",\n  \"users\": [\n    \"user1@example.com\",\n    \"user2@example.com\"\n  ],\n  \"createdAt\": \"2024-06-01T12:00:00Z\",\n  \"updatedAt\": \"2024-06-05T15:30:00Z\"\n}"
+								}
+							]
 						},
 						{
 							"name": "Create Group",
@@ -628,16 +1468,60 @@
 									}
 								},
 								"url": {
-									"raw": "{{Split API Base URL}}/groups",
+									"raw": "{{Split_API_Base_URL}}/groups",
 									"host": [
-										"{{Split API Base URL}}"
+										"{{Split_API_Base_URL}}"
 									],
 									"path": [
 										"groups"
 									]
-								}
+								},
+								"description": "**Legacy Split API doc link:** [https://docs.split.io/reference/create-group](https://docs.split.io/reference/create-group)"
 							},
-							"response": []
+							"response": [
+								{
+									"name": "Success - Group Created",
+									"originalRequest": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n    \"name\":\"enablement\",\n    \"description\":\"the enablement\"\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{Split_API_Base_URL}}/groups",
+											"host": [
+												"{{Split_API_Base_URL}}"
+											],
+											"path": [
+												"groups"
+											]
+										}
+									},
+									"status": "Created",
+									"code": 201,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json",
+											"description": ""
+										}
+									],
+									"cookie": [],
+									"body": "{\n  \"id\": \"e8613b00-abd6-11ec-9dd7-4e682933ca7c\",\n  \"name\": \"enablement\",\n  \"description\": \"the enablement\",\n  \"createdAt\": \"2024-06-10T12:00:00Z\",\n  \"updatedAt\": \"2024-06-10T12:00:00Z\"\n}"
+								}
+							]
 						},
 						{
 							"name": "Update Group",
@@ -654,17 +1538,68 @@
 									}
 								},
 								"url": {
-									"raw": "{{Split API Base URL}}/groups/{{Split Group Identifier}}",
+									"raw": "{{Split_API_Base_URL}}/groups/{{Split_Group_Identifier}}",
 									"host": [
-										"{{Split API Base URL}}"
+										"{{Split_API_Base_URL}}"
 									],
 									"path": [
 										"groups",
-										"{{Split Group Identifier}}"
+										"{{Split_Group_Identifier}}"
 									]
-								}
+								},
+								"description": "**Update Group**\n\nUpdates the name and description of a specific group in Split.\n\n**Endpoint:**  \nPUT `/groups/{{Split_Group_Identifier}}`\n\n**Path Parameter:**\n\n- `Split_Group_Identifier`: The unique identifier of the group to update.\n    \n\n**Request Body (JSON):**\n\n``` json\n{\n  \"name\": \"string\",         // The new name for the group.\n  \"description\": \"string\"   // The new description for the group.\n}\n\n ```\n\n**Behavior:**  \nThis request modifies the specified group's details. Ensure you have the correct group identifier and provide both fields in the request body.\n\n**Legacy Split API doc link:** [https://docs.split.io/reference/update-group](https://docs.split.io/reference/update-group)"
 							},
-							"response": []
+							"response": [
+								{
+									"name": "Successful Group Update",
+									"originalRequest": {
+										"method": "PUT",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n  \"name\": \"en1\",\n  \"description\": \"en1too\"\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{Split_API_Base_URL}}/groups/{{Split_Group_Identifier}}",
+											"host": [
+												"{{Split_API_Base_URL}}"
+											],
+											"path": [
+												"groups",
+												"{{Split_Group_Identifier}}"
+											],
+											"variable": [
+												{
+													"key": "Split Group Identifier",
+													"value": "{{Split_Group_Identifier}}"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json",
+											"description": ""
+										}
+									],
+									"cookie": [],
+									"body": "{\n  \"id\": \"{{Split_Group_Identifier}}\",\n  \"name\": \"en1\",\n  \"description\": \"en1too\",\n  \"updatedAt\": \"2024-06-01T12:00:00Z\"\n}"
+								}
+							]
 						},
 						{
 							"name": "Delete group",
@@ -672,17 +1607,53 @@
 								"method": "DELETE",
 								"header": [],
 								"url": {
-									"raw": "{{Split API Base URL}}/groups/{{Split Group Identifier}}",
+									"raw": "{{Split_API_Base_URL}}/groups/{{Split_Group_Identifier}}",
 									"host": [
-										"{{Split API Base URL}}"
+										"{{Split_API_Base_URL}}"
 									],
 									"path": [
 										"groups",
-										"{{Split Group Identifier}}"
+										"{{Split_Group_Identifier}}"
 									]
-								}
+								},
+								"description": "**Legacy Split API doc link:** [https://docs.split.io/reference/delete-group](https://docs.split.io/reference/delete-group)"
 							},
-							"response": []
+							"response": [
+								{
+									"name": "Successful group deletion (204 No Content)",
+									"originalRequest": {
+										"method": "DELETE",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"url": {
+											"raw": "{{Split_API_Base_URL}}/groups/{{Split_Group_Identifier}}",
+											"host": [
+												"{{Split_API_Base_URL}}"
+											],
+											"path": [
+												"groups",
+												"{{Split_Group_Identifier}}"
+											],
+											"variable": [
+												{
+													"key": "Split Group Identifier",
+													"value": "",
+													"description": "Unique identifier for the group to delete"
+												}
+											]
+										}
+									},
+									"status": "No Content",
+									"code": 204,
+									"_postman_previewlanguage": "json",
+									"header": [],
+									"cookie": [],
+									"body": "{}"
+								}
+							]
 						}
 					],
 					"description": "The `/groups` endpoint becomes unavailable to you once your account has been migrated to Harness.\n\n- This endpoint manages data **about** each group, **not its list of members**.\n    \n- For **management of members** _**in**_ **each group** see these examples in Users:\n    \n    - List Users (optionally takes group as filter)\n        \n    - Add User to Group\n        \n    - Remove User from Group",
@@ -691,7 +1662,7 @@
 						"bearer": [
 							{
 								"key": "token",
-								"value": "{{Split API Token}}",
+								"value": "{{Split_API_Token}}",
 								"type": "string"
 							}
 						]
@@ -729,14 +1700,14 @@
 								"header": [
 									{
 										"key": "x-api-key",
-										"value": "{{Harness API Token}}",
+										"value": "{{Harness_API_Token}}",
 										"type": "text"
 									}
 								],
 								"url": {
-									"raw": "{{Harness API Base URL}}/user-groups/?accountIdentifier={{Harness Account Identifier}}",
+									"raw": "{{Harness_API_Base_URL}}/user-groups/?accountIdentifier={{Harness_Account_Identifier}}",
 									"host": [
-										"{{Harness API Base URL}}"
+										"{{Harness_API_Base_URL}}"
 									],
 									"path": [
 										"user-groups",
@@ -745,13 +1716,54 @@
 									"query": [
 										{
 											"key": "accountIdentifier",
-											"value": "{{Harness Account Identifier}}"
+											"value": "{{Harness_Account_Identifier}}"
 										}
 									]
 								},
-								"description": "Docs link: [https://apidocs.harness.io/tag/User-Group#operation/getUserGroupList](https://apidocs.harness.io/tag/User-Group#operation/getUserGroupList)"
+								"description": "**Harness API doc link:** [https://apidocs.harness.io/user-group/getusergrouplist](https://apidocs.harness.io/user-group/getusergrouplist)"
 							},
-							"response": []
+							"response": [
+								{
+									"name": "200 OK - List Groups Example",
+									"originalRequest": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "x-api-key",
+												"value": "{{Harness_API_Token}}"
+											}
+										],
+										"url": {
+											"raw": "{{Harness_API_Base_URL}}/user-groups/?accountIdentifier={{Harness_Account_Identifier}}",
+											"host": [
+												"{{Harness_API_Base_URL}}"
+											],
+											"path": [
+												"user-groups",
+												""
+											],
+											"query": [
+												{
+													"key": "accountIdentifier",
+													"value": "{{Harness Account Identifier}}"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "x-api-key",
+											"value": "{{Harness_API_Token}}",
+											"description": ""
+										}
+									],
+									"cookie": [],
+									"body": "{\n  \"resource\": [\n    {\n      \"identifier\": \"_all_account_admins_\",\n      \"name\": \"All Account Admins\",\n      \"description\": \"All users with admin access to the account.\",\n      \"users\": [\n        {\n          \"identifier\": \"user1@example.com\",\n          \"name\": \"User One\"\n        },\n        {\n          \"identifier\": \"user2@example.com\",\n          \"name\": \"User Two\"\n        }\n      ],\n      \"roles\": [\n        {\n          \"identifier\": \"ACCOUNT_ADMIN\",\n          \"name\": \"Account Admin\"\n        }\n      ],\n      \"orgIdentifier\": null,\n      \"projectIdentifier\": null\n    },\n    {\n      \"identifier\": \"_all_account_fme_editors_\",\n      \"name\": \"All Account FME Editors\",\n      \"description\": \"All users with edit access to FME projects.\",\n      \"users\": [],\n      \"roles\": [\n        {\n          \"identifier\": \"FME_EDITOR\",\n          \"name\": \"FME Editor\"\n        }\n      ],\n      \"orgIdentifier\": null,\n      \"projectIdentifier\": null\n    }\n  ],\n  \"responseMessages\": []\n}"
+								}
+							]
 						},
 						{
 							"name": "Get Group",
@@ -760,29 +1772,80 @@
 								"header": [
 									{
 										"key": "x-api-key",
-										"value": "{{Harness API Token}}",
+										"value": "{{Harness_API_Token}}",
 										"type": "text"
 									}
 								],
 								"url": {
-									"raw": "{{Harness API Base URL}}/user-groups/{{Harness Group Identifier}}?accountIdentifier={{Harness Account Identifier}}",
+									"raw": "{{Harness_API_Base_URL}}/user-groups/{{Harness_Group_Identifier}}?accountIdentifier={{Harness_Account_Identifier}}",
 									"host": [
-										"{{Harness API Base URL}}"
+										"{{Harness_API_Base_URL}}"
 									],
 									"path": [
 										"user-groups",
-										"{{Harness Group Identifier}}"
+										"{{Harness_Group_Identifier}}"
 									],
 									"query": [
 										{
 											"key": "accountIdentifier",
-											"value": "{{Harness Account Identifier}}"
+											"value": "{{Harness_Account_Identifier}}"
 										}
 									]
 								},
-								"description": "Docs link: [https://apidocs.harness.io/tag/User-Group#operation/getUserGroup](https://apidocs.harness.io/tag/User-Group#operation/getUserGroup)"
+								"description": "Docs link: [https://apidocs.harness.io/user-group/getusergroup](https://apidocs.harness.io/user-group/getusergroup)"
 							},
-							"response": []
+							"response": [
+								{
+									"name": "Successful Response (200 OK)",
+									"originalRequest": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "x-api-key",
+												"value": "{{Harness_API_Token}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"url": {
+											"raw": "{{Harness_API_Base_URL}}/user-groups/{{Harness_Group_Identifier}}?accountIdentifier={{Harness_Account_Identifier}}",
+											"host": [
+												"{{Harness_API_Base_URL}}"
+											],
+											"path": [
+												"user-groups",
+												"{{Harness_Group_Identifier}}"
+											],
+											"query": [
+												{
+													"key": "accountIdentifier",
+													"value": "{{Harness Account Identifier}}"
+												}
+											],
+											"variable": [
+												{
+													"key": "Harness Group Identifier",
+													"value": "exampleGroupId"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "x-api-key",
+											"value": "{{Harness_API_Token}}",
+											"description": ""
+										}
+									],
+									"cookie": [],
+									"body": "{\n  \"resource\": {\n    \"identifier\": \"exampleGroupId\",\n    \"name\": \"Example Group Name\",\n    \"description\": \"This is an example user group in Harness.\",\n    \"users\": [\n      {\n        \"identifier\": \"user1@example.com\",\n        \"name\": \"User One\"\n      },\n      {\n        \"identifier\": \"user2@example.com\",\n        \"name\": \"User Two\"\n      }\n    ],\n    \"roles\": [\n      {\n        \"identifier\": \"_account_admin\",\n        \"name\": \"Account Admin\"\n      }\n    ],\n    \"accountIdentifier\": \"exampleAccountId\",\n    \"orgIdentifier\": null,\n    \"projectIdentifier\": null,\n    \"created\": 1710000000000,\n    \"lastModified\": 1710000000000\n  },\n  \"created\": 1710000000000,\n  \"correlationId\": \"example-correlation-id\",\n  \"metaData\": null,\n  \"status\": \"SUCCESS\"\n}"
+								}
+							]
 						},
 						{
 							"name": "Create Group",
@@ -791,7 +1854,7 @@
 								"header": [
 									{
 										"key": "x-api-key",
-										"value": "{{Harness API Token}}",
+										"value": "{{Harness_API_Token}}",
 										"type": "text"
 									}
 								],
@@ -805,9 +1868,9 @@
 									}
 								},
 								"url": {
-									"raw": "{{Harness API Base URL}}/user-groups?accountIdentifier={{Harness Account Identifier}}",
+									"raw": "{{Harness_API_Base_URL}}/user-groups?accountIdentifier={{Harness_Account_Identifier}}",
 									"host": [
-										"{{Harness API Base URL}}"
+										"{{Harness_API_Base_URL}}"
 									],
 									"path": [
 										"user-groups"
@@ -815,13 +1878,64 @@
 									"query": [
 										{
 											"key": "accountIdentifier",
-											"value": "{{Harness Account Identifier}}"
+											"value": "{{Harness_Account_Identifier}}"
 										}
 									]
 								},
-								"description": "Docs link: [https://apidocs.harness.io/tag/User-Group#operation/postUserGroup](https://apidocs.harness.io/tag/User-Group#operation/postUserGroup)"
+								"description": "**Harness API doc link:** [https://apidocs.harness.io/user-group/postusergroup](https://apidocs.harness.io/user-group/postusergroup)"
 							},
-							"response": []
+							"response": [
+								{
+									"name": "200 OK - Create Group Example",
+									"originalRequest": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "x-api-key",
+												"value": "{{Harness_API_Token}}",
+												"type": "text"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n    \"identifier\": \"theEnGroup\",\n    \"name\": \"the en group\"\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{Harness_API_Base_URL}}/user-groups?accountIdentifier={{Harness Account Identifier}}",
+											"host": [
+												"{{Harness_API_Base_URL}}"
+											],
+											"path": [
+												"user-groups"
+											],
+											"query": [
+												{
+													"key": "accountIdentifier",
+													"value": "{{Harness Account Identifier}}"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json",
+											"description": "",
+											"type": "text"
+										}
+									],
+									"cookie": [],
+									"body": "{\n  \"status\": \"SUCCESS\",\n  \"data\": {\n    \"accountIdentifier\": \"jbqowC0xTFanEXAMPLEcXAA\",\n    \"identifier\": \"group_created_via_api\",\n    \"name\": \"Group created via API\",\n    \"users\": [],\n    \"notificationConfigs\": [],\n    \"externallyManaged\": false,\n    \"description\": \"\",\n    \"tags\": {},\n    \"harnessManaged\": false,\n    \"ssoLinked\": false\n  },\n  \"metaData\": null,\n  \"correlationId\": \"12345678-1234-1234-1234-1234567890ab\"\n}"
+								}
+							]
 						},
 						{
 							"name": "Update Group",
@@ -830,7 +1944,7 @@
 								"header": [
 									{
 										"key": "x-api-key",
-										"value": "{{Harness API Token}}",
+										"value": "{{Harness_API_Token}}",
 										"type": "text"
 									}
 								],
@@ -844,9 +1958,9 @@
 									}
 								},
 								"url": {
-									"raw": "{{Harness API Base URL}}/user-groups?accountIdentifier={{Harness Account Identifier}}",
+									"raw": "{{Harness_API_Base_URL}}/user-groups?accountIdentifier={{Harness_Account_Identifier}}",
 									"host": [
-										"{{Harness API Base URL}}"
+										"{{Harness_API_Base_URL}}"
 									],
 									"path": [
 										"user-groups"
@@ -854,13 +1968,62 @@
 									"query": [
 										{
 											"key": "accountIdentifier",
-											"value": "{{Harness Account Identifier}}"
+											"value": "{{Harness_Account_Identifier}}"
 										}
 									]
 								},
-								"description": "Docs link: [https://apidocs.harness.io/tag/User-Group#operation/putUserGroup](https://apidocs.harness.io/tag/User-Group#operation/putUserGroup)"
+								"description": "**Harness API doc link:** [https://apidocs.harness.io/user-group/putusergroup](https://apidocs.harness.io/user-group/putusergroup)"
 							},
-							"response": []
+							"response": [
+								{
+									"name": "Successful Group Update",
+									"originalRequest": {
+										"method": "PUT",
+										"header": [
+											{
+												"key": "x-api-key",
+												"value": "{{Harness_API_Token}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n    \"identifier\": \"theEnGroup\",\n    \"name\": \"the enablement group\"\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{Harness_API_Base_URL}}/user-groups?accountIdentifier={{Harness_Account_Identifier}}",
+											"host": [
+												"{{Harness_API_Base_URL}}"
+											],
+											"path": [
+												"user-groups"
+											],
+											"query": [
+												{
+													"key": "accountIdentifier",
+													"value": "{{Harness Account Identifier}}"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "x-api-key",
+											"value": "{{Harness_API_Token}}",
+											"description": ""
+										}
+									],
+									"cookie": [],
+									"body": "{\n  \"status\": \"SUCCESS\",\n  \"message\": \"Group updated successfully.\",\n  \"group\": {\n    \"identifier\": \"theEnGroup\",\n    \"name\": \"the enablement group\",\n    \"description\": \"Updated group description.\",\n    \"users\": [\n      \"user1@example.com\",\n      \"user2@example.com\"\n    ],\n    \"roles\": [\n      \"Account Admin\"\n    ]\n  }\n}"
+								}
+							]
 						},
 						{
 							"name": "Delete Group",
@@ -869,29 +2032,80 @@
 								"header": [
 									{
 										"key": "x-api-key",
-										"value": "{{Harness API Token}}",
+										"value": "{{Harness_API_Token}}",
 										"type": "text"
 									}
 								],
 								"url": {
-									"raw": "{{Harness API Base URL}}/user-groups/{{Harness Group Identifier}}?accountIdentifier={{Harness Account Identifier}}",
+									"raw": "{{Harness_API_Base_URL}}/user-groups/{{Harness_Group_Identifier}}?accountIdentifier={{Harness_Account_Identifier}}",
 									"host": [
-										"{{Harness API Base URL}}"
+										"{{Harness_API_Base_URL}}"
 									],
 									"path": [
 										"user-groups",
-										"{{Harness Group Identifier}}"
+										"{{Harness_Group_Identifier}}"
 									],
 									"query": [
 										{
 											"key": "accountIdentifier",
-											"value": "{{Harness Account Identifier}}"
+											"value": "{{Harness_Account_Identifier}}"
 										}
 									]
 								},
-								"description": "Docs link: [https://apidocs.harness.io/tag/User-Group#operation/deleteUserGroup](https://apidocs.harness.io/tag/User-Group#operation/deleteUserGroup)"
+								"description": "**Harness API doc link:** [https://apidocs.harness.io/user-group/deleteusergroup](https://apidocs.harness.io/user-group/deleteusergroup)"
 							},
-							"response": []
+							"response": [
+								{
+									"name": "Successful Group Deletion",
+									"originalRequest": {
+										"method": "DELETE",
+										"header": [
+											{
+												"key": "x-api-key",
+												"value": "{{Harness_API_Token}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"url": {
+											"raw": "{{Harness_API_Base_URL}}/user-groups/{{Harness_Group_Identifier}}?accountIdentifier={{Harness_Account_Identifier}}",
+											"host": [
+												"{{Harness_API_Base_URL}}"
+											],
+											"path": [
+												"user-groups",
+												"{{Harness_Group_Identifier}}"
+											],
+											"query": [
+												{
+													"key": "accountIdentifier",
+													"value": "{{Harness Account Identifier}}"
+												}
+											],
+											"variable": [
+												{
+													"key": "Harness Group Identifier",
+													"value": "{{Harness_Group_Identifier}}"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "x-api-key",
+											"value": "{{Harness_API_Token}}",
+											"description": ""
+										}
+									],
+									"cookie": [],
+									"body": "{\n  \"status\": \"SUCCESS\",\n  \"message\": \"Group deleted successfully.\",\n  \"groupId\": \"{{Harness_Group_Identifier}}\"\n}"
+								}
+							]
 						}
 					],
 					"description": "The `/user-groups` endpoint here replaces the Split `/groups` and `/users` endpoints after migration.\n\n### **How User Groups Are Used in Harness**\n\nIn **Harness**, user groups function differently from **Split**, providing greater flexibility in managing permissions and access control.\n\n#### **Key Ways User Groups Are Used in Harness:**\n\n1. **User Groups Can Have Role Bindings**\n    \n    - In **Split**, groups were just lists of users with no assigned roles (except for Administrators).\n        \n    - In **Harness**, user groups **can be assigned one or more roles**, which determine what actions members can perform.\n        \n2. **Groups Can Exist at Different Levels**\n    \n    - In **Split**, all groups were **global (account-level only)**.\n        \n    - In **Harness**, groups can be created at the **Account, Organization, or Project level**, allowing for **more granular access control**.\n        \n3. **User Groups Control Access in RBAC**\n    \n    - In **Split**, groups granted access only be being included in **environment or object-level permissions** settings.\n        \n    - In **Harness**, groups are used **directly in Role Assignments (Role Bindings)** to manage access.\n        \n4. **Default Groups for Migrated Users**\n    \n    - **Harness automatically creates certain groups during migration** to mimic Split’s open-access behavior outside of restricted projects:\n        \n        - `_all_account_admins_` → Full access\n            \n        - `_all_account_fme_editors_` → Editing permissions\n            \n        - `_all_account_fme_viewers_` → Read-only access.\n            \n\n---\n\n### **Key Takeaways**\n\n✔ **Harness user groups manage permissions through role bindings, not just membership.**\n\n✔ **Groups exist at multiple levels (Account, Org, Project), unlike Split’s global groups.**\n\n✔ **User Groups are used in RBAC to assign permissions efficiently.**",
@@ -900,7 +2114,7 @@
 						"apikey": [
 							{
 								"key": "value",
-								"value": "{{Harness API Token}}",
+								"value": "{{Harness_API_Token}}",
 								"type": "string"
 							},
 							{
@@ -954,9 +2168,9 @@
 									}
 								],
 								"url": {
-									"raw": "{{Split API Base URL}}/workspaces",
+									"raw": "{{Split_API_Base_URL}}/workspaces",
 									"host": [
-										"{{Split API Base URL}}"
+										"{{Split_API_Base_URL}}"
 									],
 									"path": [
 										"workspaces"
@@ -979,9 +2193,64 @@
 										}
 									]
 								},
-								"description": "Retrieves the Workspaces for an organization.\n\nThe result set of the API may be subject to reduction based on the Workspace View Restrictions."
+								"description": "Retrieves the Workspaces for an organization.\n\nThe result set of the API may be subject to reduction based on the Workspace View Restrictions.\n\n**Legacy Split API doc link:** [https://docs.split.io/reference/get-workspaces](https://docs.split.io/reference/get-workspaces)"
 							},
-							"response": []
+							"response": [
+								{
+									"name": "200 OK - List of Projects",
+									"originalRequest": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"url": {
+											"raw": "{{Split_API_Base_URL}}/workspaces",
+											"host": [
+												"{{Split_API_Base_URL}}"
+											],
+											"path": [
+												"workspaces"
+											],
+											"query": [
+												{
+													"key": "name",
+													"value": "",
+													"disabled": true
+												},
+												{
+													"key": "limit",
+													"value": "",
+													"disabled": true
+												},
+												{
+													"key": "offset",
+													"value": "",
+													"disabled": true
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json",
+											"description": ""
+										}
+									],
+									"cookie": [],
+									"body": "{\n  \"objects\": [\n    {\n      \"id\": \"workspace_12345\",\n      \"name\": \"Project Alpha\",\n      \"description\": \"A sample project.\",\n      \"createdAt\": \"2023-01-01T12:00:00Z\",\n      \"updatedAt\": \"2023-01-02T12:00:00Z\"\n    },\n    {\n      \"id\": \"workspace_67890\",\n      \"name\": \"Project Beta\",\n      \"description\": \"Another project.\",\n      \"createdAt\": \"2023-02-01T12:00:00Z\",\n      \"updatedAt\": \"2023-02-02T12:00:00Z\"\n    }\n  ],\n  \"totalCount\": 2,\n  \"limit\": 20,\n  \"offset\": 0\n}"
+								}
+							]
 						},
 						{
 							"name": "Create Project",
@@ -998,17 +2267,60 @@
 									}
 								},
 								"url": {
-									"raw": "{{Split API Base URL}}/workspaces",
+									"raw": "{{Split_API_Base_URL}}/workspaces",
 									"host": [
-										"{{Split API Base URL}}"
+										"{{Split_API_Base_URL}}"
 									],
 									"path": [
 										"workspaces"
 									]
 								},
-								"description": "Allows you to create workspaces.\n\nNote: When you create a workspace from this API, this won't create the default environment. You must use the create environment API to create an environment."
+								"description": "Allows you to create workspaces.\n\nNote: When you create a workspace from this API, this won't create the default environment. You must use the create environment API to create an environment.\n\n**Legacy Split API doc link:** [https://docs.split.io/reference/create-workspace](https://docs.split.io/reference/create-workspace)"
 							},
-							"response": []
+							"response": [
+								{
+									"name": "Successful Project Creation (201 Created)",
+									"originalRequest": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n    \"name\": \"workspace name\",\n    \"requiresTitleAndComments\": true\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{Split_API_Base_URL}}/workspaces",
+											"host": [
+												"{{Split_API_Base_URL}}"
+											],
+											"path": [
+												"workspaces"
+											]
+										}
+									},
+									"status": "Created",
+									"code": 201,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json",
+											"description": ""
+										}
+									],
+									"cookie": [],
+									"body": "{\n  \"id\": \"ws_1234567890abcdef\",\n  \"name\": \"workspace name\",\n  \"requiresTitleAndComments\": true,\n  \"createdAt\": \"2024-06-01T12:34:56Z\",\n  \"updatedAt\": \"2024-06-01T12:34:56Z\"\n}"
+								}
+							]
 						},
 						{
 							"name": "Update Project",
@@ -1025,18 +2337,68 @@
 									}
 								},
 								"url": {
-									"raw": "{{Split API Base URL}}/workspaces/{{Split Workspace Identifier}}",
+									"raw": "{{Split_API_Base_URL}}/workspaces/{{Split_Workspace_Identifier}}",
 									"host": [
-										"{{Split API Base URL}}"
+										"{{Split_API_Base_URL}}"
 									],
 									"path": [
 										"workspaces",
-										"{{Split Workspace Identifier}}"
+										"{{Split_Workspace_Identifier}}"
 									]
 								},
-								"description": "This endpoint provides a partial update for a workspace."
+								"description": "This endpoint provides a partial update for a workspace.\n\n**Legacy Split API doc link:** [https://docs.split.io/reference/update-workspace](https://docs.split.io/reference/update-workspace)"
 							},
-							"response": []
+							"response": [
+								{
+									"name": "Successful Project Update",
+									"originalRequest": {
+										"method": "PATCH",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "[\n    {\n        \"op\": \"replace\",\n        \"path\": \"/name\",\n        \"value\": \"old project\"\n    },\n    {\n        \"op\": \"replace\",\n        \"path\": \"/requiresTitleAndComments\",\n        \"value\": true\n    }\n]",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{Split_API_Base_URL}}/workspaces/{{Split_Workspace_Identifier}}",
+											"host": [
+												"{{Split_API_Base_URL}}"
+											],
+											"path": [
+												"workspaces",
+												"{{Split_Workspace_Identifier}}"
+											],
+											"variable": [
+												{
+													"key": "Split Workspace Identifier",
+													"value": "{{Split_Workspace_Identifier}}"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json",
+											"description": ""
+										}
+									],
+									"cookie": [],
+									"body": "{\n  \"id\": \"{{Split_Workspace_Identifier}}\",\n  \"name\": \"old project\",\n  \"requiresTitleAndComments\": true,\n  \"updatedAt\": \"2024-06-01T12:00:00Z\"\n}"
+								}
+							]
 						},
 						{
 							"name": "Delete Project",
@@ -1044,18 +2406,53 @@
 								"method": "DELETE",
 								"header": [],
 								"url": {
-									"raw": "{{Split API Base URL}}/workspaces/{{Split Workspace Identifier}}",
+									"raw": "{{Split_API_Base_URL}}/workspaces/{{Split_Workspace_Identifier}}",
 									"host": [
-										"{{Split API Base URL}}"
+										"{{Split_API_Base_URL}}"
 									],
 									"path": [
 										"workspaces",
-										"{{Split Workspace Identifier}}"
+										"{{Split_Workspace_Identifier}}"
 									]
 								},
-								"description": "Deletes a workspace."
+								"description": "Deletes a workspace.\n\n**Legacy Split API doc link:** [https://docs.split.io/reference/delete-workspace](https://docs.split.io/reference/delete-workspace)"
 							},
-							"response": []
+							"response": [
+								{
+									"name": "Successful Deletion (204 No Content)",
+									"originalRequest": {
+										"method": "DELETE",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"url": {
+											"raw": "{{Split_API_Base_URL}}/workspaces/{{Split_Workspace_Identifier}}",
+											"host": [
+												"{{Split_API_Base_URL}}"
+											],
+											"path": [
+												"workspaces",
+												"{{Split_Workspace_Identifier}}"
+											],
+											"variable": [
+												{
+													"key": "Split Workspace Identifier",
+													"value": "",
+													"description": "Unique identifier for the workspace to delete"
+												}
+											]
+										}
+									},
+									"status": "No Content",
+									"code": 204,
+									"_postman_previewlanguage": "json",
+									"header": [],
+									"cookie": [],
+									"body": "{}"
+								}
+							]
 						}
 					],
 					"description": "`POST /workspaces`, `PATCH /workspaces`, and `DELETE /workspaces` will become unavailable when your account is migrated to Harness.\n\n`GET /workspaces` will **not** be deprecated, to support lookup of the `wsId` corresponding to a Harness Project `name`. Please see the Harness (AFTER) folder below for details.",
@@ -1064,7 +2461,7 @@
 						"bearer": [
 							{
 								"key": "token",
-								"value": "{{Split API Token}}",
+								"value": "{{Split_API_Token}}",
 								"type": "string"
 							}
 						]
@@ -1102,14 +2499,14 @@
 								"header": [
 									{
 										"key": "x-api-key",
-										"value": "{{Harness API Token}}",
+										"value": "{{Harness_API_Token}}",
 										"type": "text"
 									}
 								],
 								"url": {
-									"raw": "{{Harness API Base URL}}/projects?accountIdentifier={{Harness Account Identifier}}&orgIdentifier={{Harness Organization Identifier}}",
+									"raw": "{{Harness_API_Base_URL}}/projects?accountIdentifier={{Harness_Account_Identifier}}&orgIdentifier={{Harness_Organization_Identifier}}",
 									"host": [
-										"{{Harness API Base URL}}"
+										"{{Harness_API_Base_URL}}"
 									],
 									"path": [
 										"projects"
@@ -1117,17 +2514,61 @@
 									"query": [
 										{
 											"key": "accountIdentifier",
-											"value": "{{Harness Account Identifier}}"
+											"value": "{{Harness_Account_Identifier}}"
 										},
 										{
 											"key": "orgIdentifier",
-											"value": "{{Harness Organization Identifier}}"
+											"value": "{{Harness_Organization_Identifier}}"
 										}
 									]
 								},
-								"description": "Docs link: [https://apidocs.harness.io/tag/Project#operation/getProject](https://apidocs.harness.io/tag/Project#operation/getProject)"
+								"description": "**Harness API doc link:** [https://apidocs.harness.io/project/getprojectlist](https://apidocs.harness.io/project/getprojectlist)"
 							},
-							"response": []
+							"response": [
+								{
+									"name": "Successful Project List Retrieval (200 OK)",
+									"originalRequest": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "x-api-key",
+												"value": "{{Harness_API_Token}}"
+											}
+										],
+										"url": {
+											"raw": "{{Harness_API_Base_URL}}/projects?accountIdentifier={{Harness_Account_Identifier}}&orgIdentifier={{Harness_Organization_Identifier}}",
+											"host": [
+												"{{Harness_API_Base_URL}}"
+											],
+											"path": [
+												"projects"
+											],
+											"query": [
+												{
+													"key": "accountIdentifier",
+													"value": "{{Harness Account Identifier}}"
+												},
+												{
+													"key": "orgIdentifier",
+													"value": "{{Harness Organization Identifier}}"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "x-api-key",
+											"value": "{{Harness_API_Token}}",
+											"description": ""
+										}
+									],
+									"cookie": [],
+									"body": "{\n  \"status\": \"SUCCESS\",\n  \"data\": {\n    \"content\": [\n      {\n        \"identifier\": \"proj123\",\n        \"orgIdentifier\": \"org123\",\n        \"name\": \"NewProj\",\n        \"color\": \"yellow\",\n        \"description\": \"a new project\",\n        \"tags\": {},\n        \"modules\": [\"CD\", \"CI\"],\n        \"createdAt\": 1710000000000,\n        \"lastModifiedAt\": 1710000000000\n      }\n    ],\n    \"pageIndex\": 0,\n    \"totalPages\": 1,\n    \"totalItems\": 1,\n    \"pageSize\": 30,\n    \"empty\": false\n  },\n  \"metaData\": null,\n  \"correlationId\": \"string\"\n}"
+								}
+							]
 						},
 						{
 							"name": "Create Project",
@@ -1136,13 +2577,13 @@
 								"header": [
 									{
 										"key": "x-api-key",
-										"value": "{{Harness API Token}}",
+										"value": "{{Harness_API_Token}}",
 										"type": "text"
 									}
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"project\": {\n        \"orgIdentifier\": \"{{Harness Organization Identifier}}\",\n        \"identifier\": \"NewProj\",\n        \"name\": \"NewProj\",\n        \"color\": \"string\",\n        \"modules\": [\n            \"CD\"\n        ],\n        \"description\": \"a new project\",\n        \"tags\": {}\n    }\n}",
+									"raw": "{\n    \"project\": {\n        \"orgIdentifier\": \"{{Harness_Organization_Identifier}}\",\n        \"identifier\": \"{{Harness_Project_Identifier}}\",\n        \"name\": \"NewProj\",\n        \"color\": \"yellow\",\n        \"description\": \"a new project\",\n        \"tags\": {}\n    }\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -1150,9 +2591,9 @@
 									}
 								},
 								"url": {
-									"raw": "{{Harness API Base URL}}/projects?accountIdentifier={{Harness Account Identifier}}&orgIdentifier={{Harness Organization Identifier}}",
+									"raw": "{{Harness_API_Base_URL}}/projects?accountIdentifier={{Harness Account Identifier}}&orgIdentifier={{Harness Organization Identifier}}",
 									"host": [
-										"{{Harness API Base URL}}"
+										"{{Harness_API_Base_URL}}"
 									],
 									"path": [
 										"projects"
@@ -1168,9 +2609,62 @@
 										}
 									]
 								},
-								"description": "Docs link: [https://apidocs.harness.io/tag/Project#operation/postProject](https://apidocs.harness.io/tag/Project#operation/postProject)"
+								"description": "**Harness API doc link:** [https://apidocs.harness.io/project/postproject](https://apidocs.harness.io/project/postproject)"
 							},
-							"response": []
+							"response": [
+								{
+									"name": "Successful Project Creation (201 Created)",
+									"originalRequest": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "x-api-key",
+												"value": "{{Harness_API_Token}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n    \"project\": {\n        \"orgIdentifier\": \"{{Harness_Organization_Identifier}}\",\n        \"identifier\": \"{{Harness_Project_Identifier}}\",\n        \"name\": \"NewProj\",\n        \"color\": \"yellow\",\n        \"description\": \"a new project\",\n        \"tags\": {}\n    }\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{Harness_API_Base_URL}}/projects?accountIdentifier={{Harness_Account_Identifier}}&orgIdentifier={{Harness_Organization_Identifier}}",
+											"host": [
+												"{{Harness_API_Base_URL}}"
+											],
+											"path": [
+												"projects"
+											],
+											"query": [
+												{
+													"key": "accountIdentifier",
+													"value": "{{Harness Account Identifier}}"
+												},
+												{
+													"key": "orgIdentifier",
+													"value": "{{Harness Organization Identifier}}"
+												}
+											]
+										}
+									},
+									"status": "Created",
+									"code": 201,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "x-api-key",
+											"value": "{{Harness_API_Token}}",
+											"description": ""
+										}
+									],
+									"cookie": [],
+									"body": "{\n  \"project\": {\n    \"orgIdentifier\": \"org123\",\n    \"identifier\": \"proj123\",\n    \"name\": \"NewProj\",\n    \"color\": \"yellow\",\n    \"description\": \"a new project\",\n    \"tags\": {}\n  },\n  \"created\": true,\n  \"message\": \"Project created successfully.\"\n}"
+								}
+							]
 						},
 						{
 							"name": "Update Project",
@@ -1179,13 +2673,13 @@
 								"header": [
 									{
 										"key": "x-api-key",
-										"value": "{{Harness API Token}}",
+										"value": "{{Harness_API_Token}}",
 										"type": "text"
 									}
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"project\": {\n        \"orgIdentifier\": \"{{Harness Organization Identifier}}\",\n        \"identifier\": \"NewProj\",\n        \"name\": \"NewProjJJ\",\n        \"color\": \"string\",\n        \"modules\": [\n            \"CD\"\n        ],\n        \"description\": \"a new project\",\n        \"tags\": {}\n    }\n}",
+									"raw": "{\n    \"project\": {\n        \"orgIdentifier\": \"{{Harness_Organization_Identifier}}\",\n        \"identifier\": \"{{Harness_Project_Identifier}}\",\n        \"name\": \"UpdatedProjectName\",\n        \"color\": \"yellow\",\n        \"description\": \"a new project, with name updated\",\n        \"tags\": {}\n    }\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -1193,13 +2687,13 @@
 									}
 								},
 								"url": {
-									"raw": "{{Harness API Base URL}}/projects/{{Harness Project Identifier}}?accountIdentifier={{Harness Account Identifier}}&orgIdentifier={{Harness Organization Identifier}}",
+									"raw": "{{Harness_API_Base_URL}}/projects/{{Harness_Project_Identifier}}?accountIdentifier={{Harness Account Identifier}}&orgIdentifier={{Harness Organization Identifier}}",
 									"host": [
-										"{{Harness API Base URL}}"
+										"{{Harness_API_Base_URL}}"
 									],
 									"path": [
 										"projects",
-										"{{Harness Project Identifier}}"
+										"{{Harness_Project_Identifier}}"
 									],
 									"query": [
 										{
@@ -1212,9 +2706,65 @@
 										}
 									]
 								},
-								"description": "Docs link: [https://apidocs.harness.io/tag/Project#operation/putProject](https://apidocs.harness.io/tag/Project#operation/putProject)"
+								"description": "**Harness API doc link:** [https://apidocs.harness.io/project/putproject](https://apidocs.harness.io/project/putproject)"
 							},
-							"response": []
+							"response": [
+								{
+									"name": "200 OK - Update Project",
+									"originalRequest": {
+										"method": "PUT",
+										"header": [
+											{
+												"key": "x-api-key",
+												"value": "{{Harness_API_Token}}",
+												"type": "text"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n    \"project\": {\n        \"orgIdentifier\": \"{{Harness_Organization_Identifier}}\",\n        \"identifier\": \"{{Harness_Project_Identifier}}\",\n        \"name\": \"UpdatedProjectName\",\n        \"color\": \"yellow\",\n        \"description\": \"a new project, with name updated\",\n        \"tags\": {}\n    }\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{Harness_API_Base_URL}}/projects/{{Harness_Project_Identifier}}?accountIdentifier={{Harness Account Identifier}}&orgIdentifier={{Harness Organization Identifier}}",
+											"host": [
+												"{{Harness_API_Base_URL}}"
+											],
+											"path": [
+												"projects",
+												"{{Harness_Project_Identifier}}"
+											],
+											"query": [
+												{
+													"key": "accountIdentifier",
+													"value": "{{Harness Account Identifier}}"
+												},
+												{
+													"key": "orgIdentifier",
+													"value": "{{Harness Organization Identifier}}"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json",
+											"description": "",
+											"type": "text"
+										}
+									],
+									"cookie": [],
+									"body": "{\n  \"id\": \"string\",\n  \"type\": \"workspace\",\n  \"name\": \"string\",\n  \"requiresTitleAndComments\": true\n}"
+								}
+							]
 						},
 						{
 							"name": "Delete Project",
@@ -1223,33 +2773,98 @@
 								"header": [
 									{
 										"key": "x-api-key",
-										"value": "{{Harness API Token}}",
+										"value": "{{Harness_API_Token}}",
 										"type": "text"
 									}
 								],
 								"url": {
-									"raw": "{{Harness API Base URL}}/projects/{{Harness Project Identifier}}?accountIdentifier={{Harness Account Identifier}}&orgIdentifier={{Harness Organization Identifier}}",
+									"raw": "{{Harness_API_Base_URL}}/projects/{{Harness_Project_Identifier}}?accountIdentifier={{Harness_Account_Identifier}}&orgIdentifier={{Harness_Organization_Identifier}}",
 									"host": [
-										"{{Harness API Base URL}}"
+										"{{Harness_API_Base_URL}}"
 									],
 									"path": [
 										"projects",
-										"{{Harness Project Identifier}}"
+										"{{Harness_Project_Identifier}}"
 									],
 									"query": [
 										{
 											"key": "accountIdentifier",
-											"value": "{{Harness Account Identifier}}"
+											"value": "{{Harness_Account_Identifier}}"
 										},
 										{
 											"key": "orgIdentifier",
-											"value": "{{Harness Organization Identifier}}"
+											"value": "{{Harness_Organization_Identifier}}"
 										}
 									]
 								},
-								"description": "Docs link: [https://apidocs.harness.io/tag/Project#operation/deleteProject](https://apidocs.harness.io/tag/Project#operation/deleteProject)"
+								"description": "**Harness API doc link:** [https://apidocs.harness.io/project/deleteproject](https://apidocs.harness.io/project/deleteproject)"
 							},
-							"response": []
+							"response": [
+								{
+									"name": "Successful Project Deletion (204 No Content)",
+									"originalRequest": {
+										"method": "DELETE",
+										"header": [
+											{
+												"key": "x-api-key",
+												"value": "{{Harness_API_Token}}",
+												"description": "Harness API authentication token"
+											}
+										],
+										"url": {
+											"raw": "{{Harness_API_Base_URL}}/projects/{{Harness_Project_Identifier}}?accountIdentifier={{Harness_Account_Identifier}}&orgIdentifier={{Harness_Organization_Identifier}}",
+											"host": [
+												"{{Harness_API_Base_URL}}"
+											],
+											"path": [
+												"projects",
+												"{{Harness_Project_Identifier}}"
+											],
+											"query": [
+												{
+													"key": "accountIdentifier",
+													"value": "{{Harness Account Identifier}}",
+													"description": "Harness_Account_Identifier"
+												},
+												{
+													"key": "orgIdentifier",
+													"value": "{{Harness Organization Identifier}}",
+													"description": "Harness_Organization_Identifier"
+												}
+											],
+											"variable": [
+												{
+													"key": "Harness Project Identifier",
+													"value": "<project_id>",
+													"description": "The identifier of the Harness project to delete"
+												},
+												{
+													"key": "Harness Account Identifier",
+													"value": "<account_id>",
+													"description": "The Harness_Account_Identifier"
+												},
+												{
+													"key": "Harness Organization Identifier",
+													"value": "<org_id>",
+													"description": "The Harness_Organization_Identifier"
+												}
+											]
+										}
+									},
+									"status": "No Content",
+									"code": 204,
+									"_postman_previewlanguage": "text",
+									"header": [
+										{
+											"key": "x-api-key",
+											"value": "{{Harness_API_Token}}",
+											"description": "Harness API authentication token"
+										}
+									],
+									"cookie": [],
+									"body": "Project deleted successfully. No content returned."
+								}
+							]
 						}
 					],
 					"description": "The `/projects` endpoint here replaces the `POST`, `PATCH`, and `DELETE` verbs for the Split `/workspaces` endpoint after migration.\n\nThe `GET` verb for the Split `/workspaces` endpoint will **not** be deprecated, in order to address the following use case:\n\n#### **Retrieving** **`wsId`** **Using the Harness Project Name**\n\nIn many of the remaining Split Admin API endpoints, you will need a workspace ID, often abbreviated as `ws` or `wsId`. Here is how you can obtain the `wsId` that corresponds to a Harness project:\n\n1. **Use the** **`filter`** **Option in GET Workspaces:** Submit GET /workspaces request to the Split Admin API that used the optional query param `name` and the value of the Harness Project `name` (not the Harness Project `identifier`).\n    \n2. **Extract the** **`wsId`** **from the Response:** Once the API returns the filtered result, the **workspace ID (**`wsId`**)** will be included in the response alongside the project name.\n    \n\nNote: The usage pattern here (using the editable `name` rather than the permanent `identifier`) differs from the typical Harness API pattern, but it is the correct pattern to use when calling this Split Admin API endpoint.",
@@ -1258,7 +2873,7 @@
 						"apikey": [
 							{
 								"key": "value",
-								"value": "{{Harness API Token}}",
+								"value": "{{Harness_API_Token}}",
 								"type": "string"
 							},
 							{
@@ -1316,20 +2931,67 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"name\": \"key name wwe\",\n    \"apiKeyType\": \"admin\", // \"admin\", \"client_side\", \"server_side\"\n    \"workspace\": {\n        \"id\": \"{{Split Workspace Identifier}}\",\n        \"type\": \"workspace\"\n    },\n    \"environments\": [\n        {\n            \"id\": \"{{Split Environment Identifier}}\",\n            \"type\": \"environment\"\n        }\n        //,\n        // {\n        //     \"id\": \"environmentId2\",\n        //     \"type\": \"environment\"\n        // }\n    ]\n}"
+									"raw": "{\n    \"name\": \"key name wwe\",\n    \"apiKeyType\": \"admin\", // \"admin\", \"client_side\", \"server_side\"\n    \"workspace\": {\n        \"id\": \"{{Split_Workspace_Identifier}}\",\n        \"type\": \"workspace\"\n    },\n    \"environments\": [\n        {\n            \"id\": \"{{Split_Environment_Identifier}}\",\n            \"type\": \"environment\"\n        }\n        //,\n        // {\n        //     \"id\": \"environmentId2\",\n        //     \"type\": \"environment\"\n        // }\n    ]\n}"
 								},
 								"url": {
-									"raw": "{{Split API Base URL}}/apiKeys",
+									"raw": "{{Split_API_Base_URL}}/apiKeys",
 									"host": [
-										"{{Split API Base URL}}"
+										"{{Split_API_Base_URL}}"
 									],
 									"path": [
 										"apiKeys"
 									]
 								},
-								"description": "Create and add an API key to your organization."
+								"description": "Create and add an API key to your organization.\n\n**Legacy Split API doc link:** [https://docs.split.io/reference/create-an-api-key](https://docs.split.io/reference/create-an-api-key)"
 							},
-							"response": []
+							"response": [
+								{
+									"name": "Successful API Key Creation",
+									"originalRequest": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											},
+											{
+												"key": "Authorization",
+												"value": "Bearer {{auth-token-prod}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n    \"name\": \"key name wwe\",\n    \"apiKeyType\": \"admin\",\n    \"workspace\": {\n        \"id\": \"{{Split_Workspace_Identifier}}\",\n        \"type\": \"workspace\"\n    },\n    \"environments\": [\n        {\n            \"id\": \"{{Split_Environment_Identifier}}\",\n            \"type\": \"environment\"\n        }\n    ]\n}"
+										},
+										"url": {
+											"raw": "{{Split_API_Base_URL}}/apiKeys",
+											"host": [
+												"{{Split_API_Base_URL}}"
+											],
+											"path": [
+												"apiKeys"
+											]
+										}
+									},
+									"status": "Created",
+									"code": 201,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json",
+											"description": ""
+										},
+										{
+											"key": "Authorization",
+											"value": "Bearer {{auth-token-prod}}",
+											"description": ""
+										}
+									],
+									"cookie": [],
+									"body": "{\n  \"id\": \"api-key-1234567890\",\n  \"name\": \"key name wwe\",\n  \"apiKeyType\": \"admin\",\n  \"workspace\": {\n    \"id\": \"{{Split_Workspace_Identifier}}\",\n    \"type\": \"workspace\"\n  },\n  \"environments\": [\n    {\n      \"id\": \"{{Split_Environment_Identifier}}\",\n      \"type\": \"environment\"\n    }\n  ],\n  \"createdAt\": \"2024-06-01T12:00:00Z\",\n  \"createdBy\": \"user@example.com\",\n  \"token\": \"sk_exampletoken1234567890\"\n}"
+								}
+							]
 						},
 						{
 							"name": "Delete an Api Key",
@@ -1342,17 +3004,63 @@
 									}
 								],
 								"url": {
-									"raw": "{{Split API Base URL}}/apiKeys/{{Split Admin API Key Identifier}}",
+									"raw": "{{Split_API_Base_URL}}/apiKeys/{{Split_Admin_API_Key_Identifier}}",
 									"host": [
-										"{{Split API Base URL}}"
+										"{{Split_API_Base_URL}}"
 									],
 									"path": [
 										"apiKeys",
-										"{{Split Admin API Key Identifier}}"
+										"{{Split_Admin_API_Key_Identifier}}"
 									]
-								}
+								},
+								"description": "**Legacy Split API doc link:** [https://docs.split.io/reference/delete-an-api-key](https://docs.split.io/reference/delete-an-api-key)"
 							},
-							"response": []
+							"response": [
+								{
+									"name": "204 No Content - API Key Deleted",
+									"originalRequest": {
+										"method": "DELETE",
+										"header": [
+											{
+												"key": "Authorization",
+												"value": "Bearer {{auth-token-prod}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"url": {
+											"raw": "{{Split_API_Base_URL}}/apiKeys/{{Split_Admin_API_Key_Identifier}}",
+											"host": [
+												"{{Split_API_Base_URL}}"
+											],
+											"path": [
+												"apiKeys",
+												"{{Split_Admin_API_Key_Identifier}}"
+											],
+											"variable": [
+												{
+													"key": "Split Admin API Key Identifier",
+													"value": "admin_key_123"
+												}
+											]
+										}
+									},
+									"status": "No Content",
+									"code": 204,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Authorization",
+											"value": "Bearer {{auth-token-prod}}",
+											"description": ""
+										}
+									],
+									"cookie": [],
+									"body": "{}"
+								}
+							]
 						}
 					],
 					"description": "`POST /apiKeys` (Split Admin API key **creation)** will not available for the `admin` type API keys after your migration date.\n\n`DEL /apiKeys` (Split Admin API key **deletion)** will remain available for the `admin` type API keys after your migration date, but only to delete those keys created _before your migration_.\n\n### **SDK API Key Management Remains at This Endpoint**\n\nContinue to use this endpoint for `client_side` and `server_side` SDK API Key management.\n\n### **How Admin API Keys Are Managed in Split**\n\nIn **Split**, API key management operates differently from **Harness**, particularly in how permissions and scopes are assigned.\n\n1. **API Keys Have Direct Permissions:**\n    \n    - Each API key is **individually assigned roles and scopes**.\n        \n    - API keys control access to resources **without a service account concept**.\n        \n    - Permissions are set directly on each key, rather than inheriting permissions from a parent entity.\n        \n2. **Scopes Are Defined at the Key Level:**\n    \n    - API keys are tied to **specific resource scopes**, such as workspaces, users, or groups.\n        \n    - Users must carefully manage the scope to ensure that API keys have appropriate access.\n        \n3. **Manual Rotation and Expiration Handling:**\n    \n    - API key rotation is manual.\n        \n    - There is no built-in expiration mechanism—users must **delete and recreate keys** to manage security.\n        \n\n---\n\n### **How It Works Differently in Harness**\n\n- API keys **no longer define permissions** themselves. Instead:\n    \n    1. **Permissions are managed at the Service Account level**.\n        \n    2. **API keys inherit permissions from their parent Service Account**.\n        \n    3. **Tokens provide additional security and expiration settings**.",
@@ -1361,7 +3069,7 @@
 						"bearer": [
 							{
 								"key": "token",
-								"value": "{{Split API Token}}",
+								"value": "{{Split_API_Token}}",
 								"type": "string"
 							}
 						]
@@ -1399,13 +3107,13 @@
 								"header": [
 									{
 										"key": "x-api-key",
-										"value": "{{Harness API Token}}",
+										"value": "{{Harness_API_Token}}",
 										"type": "text"
 									}
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n  \"identifier\": \"test_service_account\",\n  \"name\": \"test service account\",\n  \"email\": \"test@gmail.com\",\n//   \"description\": \"string\",\n//   \"tags\": {\n//     \"property1\": \"string\",\n//     \"property2\": \"string\"\n//   },\n  \"accountIdentifier\": \"{{Harness Account Identifier}}\"\n//   \"orgIdentifier\": \"string\",\n//   \"projectIdentifier\": \"string\",\n//   \"governanceMetadata\": {\n//   ... <Removing this because it's thousands of lines. See https://apidocs.harness.io/tag/Service-Account#operation/listServiceAccount if you actually want to use it> ...\n//   }\n}",
+									"raw": "{\n  \"identifier\": \"test_service_account\",\n  \"name\": \"test service account\",\n  \"email\": \"test@gmail.com\",\n//   \"description\": \"string\",\n//   \"tags\": {\n//     \"property1\": \"string\",\n//     \"property2\": \"string\"\n//   },\n  \"accountIdentifier\": \"{{Harness_Account_Identifier}}\"\n//   \"orgIdentifier\": \"string\",\n//   \"projectIdentifier\": \"string\",\n//   \"governanceMetadata\": {\n//   ... <Removing this because it's thousands of lines. See https://apidocs.harness.io/tag/Service-Account#operation/listServiceAccount if you actually want to use it> ...\n//   }\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -1413,9 +3121,9 @@
 									}
 								},
 								"url": {
-									"raw": "{{Harness API Base URL}}/serviceaccount?accountIdentifier={{Harness Account Identifier}}",
+									"raw": "{{Harness_API_Base_URL}}/serviceaccount?accountIdentifier={{Harness_Account_Identifier}}",
 									"host": [
-										"{{Harness API Base URL}}"
+										"{{Harness_API_Base_URL}}"
 									],
 									"path": [
 										"serviceaccount"
@@ -1423,13 +3131,62 @@
 									"query": [
 										{
 											"key": "accountIdentifier",
-											"value": "{{Harness Account Identifier}}"
+											"value": "{{Harness_Account_Identifier}}"
 										}
 									]
 								},
-								"description": "Docs link: [https://apidocs.harness.io/tag/Service-Account#operation/createServiceAccount](https://apidocs.harness.io/tag/Service-Account#operation/createServiceAccount)"
+								"description": "**Harness API doc link:** [https://apidocs.harness.io/service-account/createserviceaccount](https://apidocs.harness.io/service-account/createserviceaccount)"
 							},
-							"response": []
+							"response": [
+								{
+									"name": "Success - Service Account Created",
+									"originalRequest": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "x-api-key",
+												"value": "{{Harness_API_Token}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n  \"identifier\": \"test_service_account\",\n  \"name\": \"test service account\",\n  \"email\": \"test@gmail.com\",\n  \"accountIdentifier\": \"{{Harness_Account_Identifier}}\"\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{Harness_API_Base_URL}}/serviceaccount?accountIdentifier={{Harness_Account_Identifier}}",
+											"host": [
+												"{{Harness_API_Base_URL}}"
+											],
+											"path": [
+												"serviceaccount"
+											],
+											"query": [
+												{
+													"key": "accountIdentifier",
+													"value": "{{Harness Account Identifier}}"
+												}
+											]
+										}
+									},
+									"status": "Created",
+									"code": 201,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "x-api-key",
+											"value": "{{Harness_API_Token}}",
+											"description": ""
+										}
+									],
+									"cookie": [],
+									"body": "{\n  \"status\": \"SUCCESS\",\n  \"data\": {\n    \"identifier\": \"test_service_account\",\n    \"name\": \"test service account\",\n    \"email\": \"test@gmail.com\",\n    \"accountIdentifier\": \"{{Harness_Account_Identifier}}\",\n    \"createdAt\": 1710000000000,\n    \"updatedAt\": 1710000000000,\n    \"tags\": {},\n    \"description\": \"Service account for automation\",\n    \"orgIdentifier\": null,\n    \"projectIdentifier\": null\n  },\n  \"metaData\": null,\n  \"correlationId\": \"abc123xyz\"\n}"
+								}
+							]
 						},
 						{
 							"name": "Create API Key",
@@ -1438,13 +3195,13 @@
 								"header": [
 									{
 										"key": "x-api-key",
-										"value": "{{Harness API Token}}",
+										"value": "{{Harness_API_Token}}",
 										"type": "text"
 									}
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n  \"identifier\": \"test_api_key\",\n  \"name\": \"test api key\",\n//   \"description\": \"string\",\n//   \"tags\": {\n//     \"property1\": \"string\",\n//     \"property2\": \"string\"\n//   },\n  \"apiKeyType\": \"SERVICE_ACCOUNT\",\n  \"parentIdentifier\": \"test_service_account\",\n//   \"defaultTimeToExpireToken\": 0,\n  \"accountIdentifier\": \"{{Harness Account Identifier}}\"\n//   \"projectIdentifier\": \"string\",\n//   \"orgIdentifier\": \"string\",\n//   \"governanceMetadata\": {\n   //   ... <Removing this because it's thousands of lines. See https://apidocs.harness.io/tag/ApiKey#operation/createApiKey if you actually want to use it> ...\n//  }\n}",
+									"raw": "{\n  \"identifier\": \"test_api_key\",\n  \"name\": \"test api key\",\n//   \"description\": \"string\",\n//   \"tags\": {\n//     \"property1\": \"string\",\n//     \"property2\": \"string\"\n//   },\n  \"apiKeyType\": \"SERVICE_ACCOUNT\",\n  \"parentIdentifier\": \"test_service_account\",\n//   \"defaultTimeToExpireToken\": 0,\n  \"accountIdentifier\": \"{{Harness_Account_Identifier}}\"\n//   \"projectIdentifier\": \"string\",\n//   \"orgIdentifier\": \"string\",\n//   \"governanceMetadata\": {\n   //   ... <Removing this because it's thousands of lines. See https://apidocs.harness.io/tag/ApiKey#operation/createApiKey if you actually want to use it> ...\n//  }\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -1452,9 +3209,9 @@
 									}
 								},
 								"url": {
-									"raw": "{{Harness API Base URL}}/apikey?accountIdentifier={{Harness Account Identifier}}",
+									"raw": "{{Harness_API_Base_URL}}/apikey?accountIdentifier={{Harness_Account_Identifier}}",
 									"host": [
-										"{{Harness API Base URL}}"
+										"{{Harness_API_Base_URL}}"
 									],
 									"path": [
 										"apikey"
@@ -1462,13 +3219,106 @@
 									"query": [
 										{
 											"key": "accountIdentifier",
-											"value": "{{Harness Account Identifier}}"
+											"value": "{{Harness_Account_Identifier}}"
 										}
 									]
 								},
-								"description": "Docs link: [https://apidocs.harness.io/tag/ApiKey#operation/createApiKey](https://apidocs.harness.io/tag/ApiKey#operation/createApiKey)"
+								"description": "**Harness API doc link:** [https://apidocs.harness.io/apikey/createapikey](https://apidocs.harness.io/apikey/createapikey)"
 							},
-							"response": []
+							"response": [
+								{
+									"name": "201 Created - API Key Created Successfully",
+									"originalRequest": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "x-api-key",
+												"value": "{{Harness_API_Token}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n  \"identifier\": \"test_api_key\",\n  \"name\": \"test api key\",\n  \"apiKeyType\": \"SERVICE_ACCOUNT\",\n  \"parentIdentifier\": \"test_service_account\",\n  \"accountIdentifier\": \"{{Harness_Account_Identifier}}\"\n}",
+											"options": {
+												"raw": "json"
+											}
+										},
+										"url": {
+											"raw": "{{Harness_API_Base_URL}}/apikey?accountIdentifier={{Harness_Account_Identifier}}",
+											"host": [
+												"{{Harness_API_Base_URL}}"
+											],
+											"path": [
+												"apikey"
+											],
+											"query": [
+												{
+													"key": "accountIdentifier",
+													"value": "{{Harness Account Identifier}}"
+												}
+											]
+										}
+									},
+									"status": "Created",
+									"code": 201,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "x-api-key",
+											"value": "{{Harness_API_Token}}",
+											"description": ""
+										}
+									],
+									"cookie": [],
+									"body": "{\n  \"resource\": {\n    \"identifier\": \"test_api_key\",\n    \"name\": \"test api key\",\n    \"apiKeyType\": \"SERVICE_ACCOUNT\",\n    \"parentIdentifier\": \"test_service_account\",\n    \"accountIdentifier\": \"{{Harness_Account_Identifier}}\",\n    \"created\": true,\n    \"active\": true,\n    \"defaultTimeToExpireToken\": null,\n    \"tags\": {},\n    \"createdAt\": 1710000000000,\n    \"lastModifiedAt\": 1710000000000\n  },\n  \"created\": true,\n  \"correlationId\": \"string\"\n}"
+								},
+								{
+									"name": "201 Created - API Key Created Successfully",
+									"originalRequest": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "x-api-key",
+												"value": "{{Harness_API_Token}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n  \"identifier\": \"test_api_key\",\n  \"name\": \"test api key\",\n  \"apiKeyType\": \"SERVICE_ACCOUNT\",\n  \"parentIdentifier\": \"test_service_account\",\n  \"accountIdentifier\": \"{{Harness_Account_Identifier}}\"\n}",
+											"options": {
+												"raw": "json"
+											}
+										},
+										"url": {
+											"raw": "{{Harness_API_Base_URL}}/apikey?accountIdentifier={{Harness_Account_Identifier}}",
+											"host": [
+												"{{Harness_API_Base_URL}}"
+											],
+											"path": [
+												"apikey"
+											],
+											"query": [
+												{
+													"key": "accountIdentifier",
+													"value": "{{Harness Account Identifier}}"
+												}
+											]
+										}
+									},
+									"status": "Created",
+									"code": 201,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "x-api-key",
+											"value": "{{Harness_API_Token}}",
+											"description": ""
+										}
+									],
+									"cookie": [],
+									"body": "{\n  \"resource\": {\n    \"identifier\": \"test_api_key\",\n    \"name\": \"test api key\",\n    \"apiKeyType\": \"SERVICE_ACCOUNT\",\n    \"parentIdentifier\": \"test_service_account\",\n    \"accountIdentifier\": \"{{Harness_Account_Identifier}}\",\n    \"created\": true,\n    \"active\": true,\n    \"defaultTimeToExpireToken\": null,\n    \"tags\": {},\n    \"createdAt\": 1710000000000,\n    \"lastModifiedAt\": 1710000000000\n  },\n  \"created\": true,\n  \"correlationId\": \"string\"\n}"
+								}
+							]
 						},
 						{
 							"name": "Give API Key Permissions",
@@ -1477,7 +3327,7 @@
 								"header": [
 									{
 										"key": "x-api-key",
-										"value": "{{Harness API Token}}",
+										"value": "{{Harness_API_Token}}",
 										"type": "text"
 									}
 								],
@@ -1491,9 +3341,9 @@
 									}
 								},
 								"url": {
-									"raw": "{{Harness Auth Base URL}}/roleassignments?accountIdentifier={{Harness Account Identifier}}",
+									"raw": "{{Harness_Auth_Base_URL}}/roleassignments?accountIdentifier={{Harness_Account_Identifier}}",
 									"host": [
-										"{{Harness Auth Base URL}}"
+										"{{Harness_Auth_Base_URL}}"
 									],
 									"path": [
 										"roleassignments"
@@ -1501,13 +3351,62 @@
 									"query": [
 										{
 											"key": "accountIdentifier",
-											"value": "{{Harness Account Identifier}}"
+											"value": "{{Harness_Account_Identifier}}"
 										}
 									]
 								},
-								"description": "Docs link: [https://apidocs.harness.io/tag/Role-Assignments#operation/postRoleAssignment](https://apidocs.harness.io/tag/Role-Assignments#operation/postRoleAssignment)"
+								"description": "**Harness API doc link:** [https://apidocs.harness.io/role-assignments/postroleassignment](https://apidocs.harness.io/role-assignments/postroleassignment)"
 							},
-							"response": []
+							"response": [
+								{
+									"name": "Successful Role Assignment Creation (201 Created)",
+									"originalRequest": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "x-api-key",
+												"value": "{{Harness_API_Token}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n  \"identifier\": \"example_role_assignment\",\n  \"resourceGroupIdentifier\": \"_all_account_level_resources\",\n  \"roleIdentifier\": \"_account_admin\",\n  \"roleReference\": {\n    \"identifier\": \"_account_admin\",\n    \"scopeLevel\": \"ACCOUNT\"\n  },\n  \"principal\": {\n    \"scope\": \"ACCOUNT\",\n    \"identifier\": \"test_service_account\",\n    \"type\": \"SERVICE_ACCOUNT\"\n  },\n  \"disabled\": false,\n  \"managed\": false,\n  \"internal\": false\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{Harness_Auth_Base_URL}}/roleassignments?accountIdentifier={{Harness_Account_Identifier}}",
+											"host": [
+												"{{Harness_Auth_Base_URL}}"
+											],
+											"path": [
+												"roleassignments"
+											],
+											"query": [
+												{
+													"key": "accountIdentifier",
+													"value": "{{Harness Account Identifier}}"
+												}
+											]
+										}
+									},
+									"status": "Created",
+									"code": 201,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "x-api-key",
+											"value": "{{Harness_API_Token}}",
+											"description": ""
+										}
+									],
+									"cookie": [],
+									"body": "{\n  \"roleAssignment\": {\n    \"identifier\": \"example_role_assignment\",\n    \"resourceGroupIdentifier\": \"_all_account_level_resources\",\n    \"roleIdentifier\": \"_account_admin\",\n    \"roleReference\": {\n      \"identifier\": \"_account_admin\",\n      \"scopeLevel\": \"ACCOUNT\"\n    },\n    \"principal\": {\n      \"scope\": \"ACCOUNT\",\n      \"identifier\": \"test_service_account\",\n      \"type\": \"SERVICE_ACCOUNT\"\n    },\n    \"disabled\": false,\n    \"managed\": false,\n    \"internal\": false\n  },\n  \"created\": true,\n  \"message\": \"Role assignment created successfully.\"\n}"
+								}
+							]
 						},
 						{
 							"name": "Create Token for API Key",
@@ -1516,13 +3415,13 @@
 								"header": [
 									{
 										"key": "x-api-key",
-										"value": "{{Harness API Token}}",
+										"value": "{{Harness_API_Token}}",
 										"type": "text"
 									}
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n  \"identifier\": \"test_token2\",\n  \"name\": \"test token 2\",\n//   \"validFrom\": 0,\n//   \"validTo\": 0,\n//   \"scheduledExpireTime\": 0,\n//   \"valid\": true,\n  \"accountIdentifier\": \"{{Harness Account Identifier}}\",\n//   \"projectIdentifier\": \"string\",\n//   \"orgIdentifier\": \"string\",\n  \"apiKeyIdentifier\": \"test_api_key\",\n  \"parentIdentifier\": \"test_service_account\",\n  \"apiKeyType\": \"SERVICE_ACCOUNT\"\n//   \"description\": \"string\",\n//   \"tags\": {\n//     \"property1\": \"string\",\n//     \"property2\": \"string\"\n//   },\n//   \"sshKeyContent\": \"string\",\n//   \"sshKeyUsage\": [\n//     \"AUTH\"\n//   ]\n}\n",
+									"raw": "{\n  \"identifier\": \"test_token2\",\n  \"name\": \"test token 2\",\n//   \"validFrom\": 0,\n//   \"validTo\": 0,\n//   \"scheduledExpireTime\": 0,\n//   \"valid\": true,\n  \"accountIdentifier\": \"{{Harness_Account_Identifier}}\",\n//   \"projectIdentifier\": \"string\",\n//   \"orgIdentifier\": \"string\",\n  \"apiKeyIdentifier\": \"test_api_key\",\n  \"parentIdentifier\": \"test_service_account\",\n  \"apiKeyType\": \"SERVICE_ACCOUNT\"\n//   \"description\": \"string\",\n//   \"tags\": {\n//     \"property1\": \"string\",\n//     \"property2\": \"string\"\n//   },\n//   \"sshKeyContent\": \"string\",\n//   \"sshKeyUsage\": [\n//     \"AUTH\"\n//   ]\n}\n",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -1530,9 +3429,9 @@
 									}
 								},
 								"url": {
-									"raw": "{{Harness API Base URL}}/token?accountIdentifier={{Harness Account Identifier}}",
+									"raw": "{{Harness_API_Base_URL}}/token?accountIdentifier={{Harness_Account_Identifier}}",
 									"host": [
-										"{{Harness API Base URL}}"
+										"{{Harness_API_Base_URL}}"
 									],
 									"path": [
 										"token"
@@ -1540,13 +3439,60 @@
 									"query": [
 										{
 											"key": "accountIdentifier",
-											"value": "{{Harness Account Identifier}}"
+											"value": "{{Harness_Account_Identifier}}"
 										}
 									]
 								},
-								"description": "Docs link: [https://apidocs.harness.io/tag/Token#operation/createToken](https://apidocs.harness.io/tag/Token#operation/createToken)"
+								"description": "**Harness API doc link:** [https://apidocs.harness.io/token/createtoken](https://apidocs.harness.io/token/createtoken)"
 							},
-							"response": []
+							"response": [
+								{
+									"name": "Successful Token Creation (201 Created)",
+									"originalRequest": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "x-api-key",
+												"value": "{{Harness_API_Token}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n  \"identifier\": \"test_token2\",\n  \"name\": \"test token 2\",\n  \"accountIdentifier\": \"{{Harness_Account_Identifier}}\",\n  \"apiKeyIdentifier\": \"test_api_key\",\n  \"parentIdentifier\": \"test_service_account\",\n  \"apiKeyType\": \"SERVICE_ACCOUNT\"\n}",
+											"options": {
+												"raw": "json"
+											}
+										},
+										"url": {
+											"raw": "{{Harness_API_Base_URL}}/token?accountIdentifier={{Harness_Account_Identifier}}",
+											"host": [
+												"{{Harness_API_Base_URL}}"
+											],
+											"path": [
+												"token"
+											],
+											"query": [
+												{
+													"key": "accountIdentifier",
+													"value": "{{Harness Account Identifier}}"
+												}
+											]
+										}
+									},
+									"status": "Created",
+									"code": 201,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "x-api-key",
+											"value": "{{Harness_API_Token}}",
+											"description": ""
+										}
+									],
+									"cookie": [],
+									"body": "{\n  \"resource\": {\n    \"identifier\": \"test_token2\",\n    \"name\": \"test token 2\",\n    \"apiKeyIdentifier\": \"test_api_key\",\n    \"parentIdentifier\": \"test_service_account\",\n    \"apiKeyType\": \"SERVICE_ACCOUNT\",\n    \"token\": \"<token_value>\",\n    \"validFrom\": 1710000000000,\n    \"validTo\": 1720000000000,\n    \"accountIdentifier\": \"{{Harness_Account_Identifier}}\",\n    \"createdAt\": 1710000000000,\n    \"lastModifiedAt\": 1710000000000\n  },\n  \"created\": true,\n  \"correlationId\": \"abc123xyz\"\n}"
+								}
+							]
 						},
 						{
 							"name": "Rotate a Token",
@@ -1555,7 +3501,7 @@
 								"header": [
 									{
 										"key": "x-api-key",
-										"value": "{{Harness API Token}}",
+										"value": "{{Harness_API_Token}}",
 										"type": "text"
 									}
 								],
@@ -1569,41 +3515,103 @@
 									}
 								},
 								"url": {
-									"raw": "{{Harness API Base URL}}/token/rotate/{{Harness Token Identifier}}?accountIdentifier={{Harness Account Identifier}}&apiKeyType={{Harness API Key Type}}&parentIdentifier={{Harness Parent Identifier}}&apiKeyIdentifier={{Harness API Key Identifier}}&rotateTimestamp={{Harness Rotate Timestamp}}",
+									"raw": "{{Harness_API_Base_URL}}/token/rotate/{{Harness_Token_Identifier}}?accountIdentifier={{Harness_Account_Identifier}}&apiKeyType={{Harness_API_Key_Type}}&parentIdentifier={{Harness_Parent_Identifier}}&apiKeyIdentifier={{Harness_API_Key_Identifier}}&rotateTimestamp={{Harness_Rotate_Timestamp}}",
 									"host": [
-										"{{Harness API Base URL}}"
+										"{{Harness_API_Base_URL}}"
 									],
 									"path": [
 										"token",
 										"rotate",
-										"{{Harness Token Identifier}}"
+										"{{Harness_Token_Identifier}}"
 									],
 									"query": [
 										{
 											"key": "accountIdentifier",
-											"value": "{{Harness Account Identifier}}"
+											"value": "{{Harness_Account_Identifier}}"
 										},
 										{
 											"key": "apiKeyType",
-											"value": "{{Harness API Key Type}}"
+											"value": "{{Harness_API_Key_Type}}"
 										},
 										{
 											"key": "parentIdentifier",
-											"value": "{{Harness Parent Identifier}}"
+											"value": "{{Harness_Parent_Identifier}}"
 										},
 										{
 											"key": "apiKeyIdentifier",
-											"value": "{{Harness API Key Identifier}}"
+											"value": "{{Harness_API_Key_Identifier}}"
 										},
 										{
 											"key": "rotateTimestamp",
-											"value": "{{Harness Rotate Timestamp}}"
+											"value": "{{Harness_Rotate_Timestamp}}"
 										}
 									]
 								},
-								"description": "Docs link: [https://apidocs.harness.io/tag/Token#operation/rotateToken](https://apidocs.harness.io/tag/Token#operation/rotateToken)"
+								"description": "**Harness API doc link:** [https://apidocs.harness.io/token/rotatetoken](https://apidocs.harness.io/token/rotatetoken)"
 							},
-							"response": []
+							"response": [
+								{
+									"name": "200 OK - Rotate a Token Example",
+									"originalRequest": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "x-api-key",
+												"value": "{{Harness_API_Token}}",
+												"type": "text"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{Harness_API_Base_URL}}/token/rotate/{{Harness_Token_Identifier}}?accountIdentifier={{Harness Account Identifier}}&apiKeyType={{Harness API Key Type}}&parentIdentifier={{Harness Parent Identifier}}&apiKeyIdentifier={{Harness API Key Identifier}}&rotateTimestamp={{Harness Rotate Timestamp}}",
+											"host": [
+												"{{Harness_API_Base_URL}}"
+											],
+											"path": [
+												"token",
+												"rotate",
+												"{{Harness_Token_Identifier}}"
+											],
+											"query": [
+												{
+													"key": "accountIdentifier",
+													"value": "{{Harness Account Identifier}}"
+												},
+												{
+													"key": "apiKeyType",
+													"value": "{{Harness API Key Type}}"
+												},
+												{
+													"key": "parentIdentifier",
+													"value": "{{Harness Parent Identifier}}"
+												},
+												{
+													"key": "apiKeyIdentifier",
+													"value": "{{Harness API Key Identifier}}"
+												},
+												{
+													"key": "rotateTimestamp",
+													"value": "{{Harness Rotate Timestamp}}"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": null,
+									"header": null,
+									"cookie": [],
+									"body": "{\n  \"status\": \"SUCCESS\",\n  \"data\": \"string\",\n  \"metaData\": {},\n  \"correlationId\": \"string\"\n}"
+								}
+							]
 						},
 						{
 							"name": "List Service Accounts",
@@ -1615,7 +3623,7 @@
 								"header": [
 									{
 										"key": "x-api-key",
-										"value": "{{Harness API Token}}",
+										"value": "{{Harness_API_Token}}",
 										"type": "text"
 									}
 								],
@@ -1629,9 +3637,9 @@
 									}
 								},
 								"url": {
-									"raw": "{{Harness API Base URL}}/serviceaccount?accountIdentifier={{Harness Account Identifier}}",
+									"raw": "{{Harness_API_Base_URL}}/serviceaccount?accountIdentifier={{Harness_Account_Identifier}}",
 									"host": [
-										"{{Harness API Base URL}}"
+										"{{Harness_API_Base_URL}}"
 									],
 									"path": [
 										"serviceaccount"
@@ -1639,13 +3647,62 @@
 									"query": [
 										{
 											"key": "accountIdentifier",
-											"value": "{{Harness Account Identifier}}"
+											"value": "{{Harness_Account_Identifier}}"
 										}
 									]
 								},
-								"description": "Docs link for \"Get Service Accounts\": [https://apidocs.harness.io/tag/Service-Account#operation/listServiceAccount](https://apidocs.harness.io/tag/Service-Account#operation/listServiceAccount)\n\nSee also docs for \"List Aggregated Service Accounts\" [https://apidocs.harness.io/tag/Service-Account#operation/listAggregatedServiceAccounts](https://apidocs.harness.io/tag/Service-Account#operation/listAggregatedServiceAccounts)"
+								"description": "**Harness API doc link - Get Service Accounts:** [https://apidocs.harness.io/service-account/listserviceaccount](https://apidocs.harness.io/service-account/listserviceaccount)\n\nSee also:\n\n**Harness API doc link - List Aggregated Service Accounts:** [https://apidocs.harness.io/service-account/listaggregatedserviceaccounts](https://apidocs.harness.io/service-account/listaggregatedserviceaccounts)"
 							},
-							"response": []
+							"response": [
+								{
+									"name": "200 OK - List of Service Accounts",
+									"originalRequest": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "x-api-key",
+												"value": "{{Harness_API_Token}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{Harness_API_Base_URL}}/serviceaccount?accountIdentifier={{Harness_Account_Identifier}}",
+											"host": [
+												"{{Harness_API_Base_URL}}"
+											],
+											"path": [
+												"serviceaccount"
+											],
+											"query": [
+												{
+													"key": "accountIdentifier",
+													"value": "{{Harness Account Identifier}}"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "x-api-key",
+											"value": "{{Harness_API_Token}}",
+											"description": ""
+										}
+									],
+									"cookie": [],
+									"body": "{\n  \"resource\": [\n    {\n      \"identifier\": \"service_account_1\",\n      \"name\": \"Service Account 1\",\n      \"email\": \"svc-account1@example.com\",\n      \"description\": \"A service account for automation.\",\n      \"accountIdentifier\": \"{{Harness_Account_Identifier}}\",\n      \"orgIdentifier\": null,\n      \"projectIdentifier\": null,\n      \"createdAt\": 1710000000000,\n      \"lastModifiedAt\": 1710000000000,\n      \"tags\": {}\n    },\n    {\n      \"identifier\": \"service_account_2\",\n      \"name\": \"Service Account 2\",\n      \"email\": \"svc-account2@example.com\",\n      \"description\": \"Another service account.\",\n      \"accountIdentifier\": \"{{Harness_Account_Identifier}}\",\n      \"orgIdentifier\": \"org1\",\n      \"projectIdentifier\": \"proj1\",\n      \"createdAt\": 1710000000000,\n      \"lastModifiedAt\": 1710000000000,\n      \"tags\": {\"env\": \"prod\"}\n    }\n  ],\n  \"total\": 2,\n  \"pageIndex\": 0,\n  \"pageSize\": 50,\n  \"correlationId\": \"abc123xyz\"\n}"
+								}
+							]
 						},
 						{
 							"name": "List API Keys",
@@ -1657,7 +3714,7 @@
 								"header": [
 									{
 										"key": "x-api-key",
-										"value": "{{Harness API Token}}",
+										"value": "{{Harness_API_Token}}",
 										"type": "text"
 									}
 								],
@@ -1671,9 +3728,9 @@
 									}
 								},
 								"url": {
-									"raw": "{{Harness API Base URL}}/apikey?accountIdentifier={{Harness Account Identifier}}&apiKeyType={{Harness API Key Type}}&parentIdentifier={{Harness Parent Identifier}}",
+									"raw": "{{Harness_API_Base_URL}}/apikey?accountIdentifier={{Harness_Account_Identifier}}&apiKeyType={{Harness_API_Key_Type}}&parentIdentifier={{Harness_Parent_Identifier}}",
 									"host": [
-										"{{Harness API Base URL}}"
+										"{{Harness_API_Base_URL}}"
 									],
 									"path": [
 										"apikey"
@@ -1681,21 +3738,78 @@
 									"query": [
 										{
 											"key": "accountIdentifier",
-											"value": "{{Harness Account Identifier}}"
+											"value": "{{Harness_Account_Identifier}}"
 										},
 										{
 											"key": "apiKeyType",
-											"value": "{{Harness API Key Type}}"
+											"value": "{{Harness_API_Key_Type}}"
 										},
 										{
 											"key": "parentIdentifier",
-											"value": "{{Harness Parent Identifier}}"
+											"value": "{{Harness_Parent_Identifier}}"
 										}
 									]
 								},
-								"description": "Docs link: [https://apidocs.harness.io/tag/ApiKey#operation/listApiKeys_1](https://apidocs.harness.io/tag/ApiKey#operation/listApiKeys_1)\n\nSee also docs for aggregated list: [https://apidocs.harness.io/tag/ApiKey#operation/listApiKeys](https://apidocs.harness.io/tag/ApiKey#operation/listApiKeys)"
+								"description": "**Harness API doc link - List API keys:** [https://apidocs.harness.io/apikey/listapikeys_1](https://apidocs.harness.io/apikey/listapikeys_1)\n\nSee also:\n\n**Harness API doc link - LIst Aggregated API keys:** [https://apidocs.harness.io/apikey/listapikeys](https://apidocs.harness.io/apikey/listapikeys)"
 							},
-							"response": []
+							"response": [
+								{
+									"name": "200 OK - List API Keys Success Example",
+									"originalRequest": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "x-api-key",
+												"value": "{{Harness_API_Token}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{Harness_API_Base_URL}}/apikey?accountIdentifier={{Harness_Account_Identifier}}&apiKeyType={{Harness_API_Key_Type}}&parentIdentifier={{Harness_Parent_Identifier}}",
+											"host": [
+												"{{Harness_API_Base_URL}}"
+											],
+											"path": [
+												"apikey"
+											],
+											"query": [
+												{
+													"key": "accountIdentifier",
+													"value": "{{Harness Account Identifier}}"
+												},
+												{
+													"key": "apiKeyType",
+													"value": "{{Harness API Key Type}}"
+												},
+												{
+													"key": "parentIdentifier",
+													"value": "{{Harness Parent Identifier}}"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "x-api-key",
+											"value": "{{Harness_API_Token}}",
+											"description": ""
+										}
+									],
+									"cookie": [],
+									"body": "{\n  \"status\": \"SUCCESS\",\n  \"data\": [\n    {\n      \"identifier\": \"api_key_1\",\n      \"name\": \"My API Key\",\n      \"parentIdentifier\": \"service_account_1\",\n      \"apiKeyType\": \"SERVICE_ACCOUNT\",\n      \"created\": \"2024-06-01T12:00:00Z\",\n      \"lastModified\": \"2024-06-01T12:00:00Z\",\n      \"enabled\": true\n    },\n    {\n      \"identifier\": \"api_key_2\",\n      \"name\": \"Another API Key\",\n      \"parentIdentifier\": \"service_account_2\",\n      \"apiKeyType\": \"SERVICE_ACCOUNT\",\n      \"created\": \"2024-06-02T08:30:00Z\",\n      \"lastModified\": \"2024-06-02T08:30:00Z\",\n      \"enabled\": false\n    }\n  ],\n  \"metaData\": {\n    \"page\": 0,\n    \"size\": 2,\n    \"total\": 2\n  },\n  \"correlationId\": \"abc123xyz\"\n}"
+								}
+							]
 						},
 						{
 							"name": "Get API Key",
@@ -1707,7 +3821,7 @@
 								"header": [
 									{
 										"key": "x-api-key",
-										"value": "{{Harness API Token}}",
+										"value": "{{Harness_API_Token}}",
 										"type": "text"
 									}
 								],
@@ -1721,33 +3835,98 @@
 									}
 								},
 								"url": {
-									"raw": "{{Harness API Base URL}}/apikey/aggregate/{{Harness API Key Identifier}}?accountIdentifier={{Harness Account Identifier}}&apiKeyType={{Harness API Key Type}}&parentIdentifier={{Harness Parent Identifier}}",
+									"raw": "{{Harness_API_Base_URL}}/apikey/aggregate/{{Harness_API_Key_Identifier}}?accountIdentifier={{Harness_Account_Identifier}}&apiKeyType={{Harness_API_Key_Type}}&parentIdentifier={{Harness_Parent_Identifier}}",
 									"host": [
-										"{{Harness API Base URL}}"
+										"{{Harness_API_Base_URL}}"
 									],
 									"path": [
 										"apikey",
 										"aggregate",
-										"{{Harness API Key Identifier}}"
+										"{{Harness_API_Key_Identifier}}"
 									],
 									"query": [
 										{
 											"key": "accountIdentifier",
-											"value": "{{Harness Account Identifier}}"
+											"value": "{{Harness_Account_Identifier}}"
 										},
 										{
 											"key": "apiKeyType",
-											"value": "{{Harness API Key Type}}"
+											"value": "{{Harness_API_Key_Type}}"
 										},
 										{
 											"key": "parentIdentifier",
-											"value": "{{Harness Parent Identifier}}"
+											"value": "{{Harness_Parent_Identifier}}"
 										}
 									]
 								},
-								"description": "Docs link: [https://apidocs.harness.io/tag/ApiKey#operation/getAggregatedApiKey](https://apidocs.harness.io/tag/ApiKey#operation/getAggregatedApiKey)"
+								"description": "Docs link: [https://apidocs.harness.io/apikey/getaggregatedapikey](https://apidocs.harness.io/apikey/getaggregatedapikey)"
 							},
-							"response": []
+							"response": [
+								{
+									"name": "Successful Response (200 OK)",
+									"originalRequest": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "x-api-key",
+												"value": "{{Harness_API_Token}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{Harness_API_Base_URL}}/apikey/aggregate/{{Harness_API_Key_Identifier}}?accountIdentifier={{Harness_Account_Identifier}}&apiKeyType={{Harness_API_Key_Type}}&parentIdentifier={{Harness_Parent_Identifier}}",
+											"host": [
+												"{{Harness_API_Base_URL}}"
+											],
+											"path": [
+												"apikey",
+												"aggregate",
+												"{{Harness_API_Key_Identifier}}"
+											],
+											"query": [
+												{
+													"key": "accountIdentifier",
+													"value": "{{Harness Account Identifier}}"
+												},
+												{
+													"key": "apiKeyType",
+													"value": "{{Harness API Key Type}}"
+												},
+												{
+													"key": "parentIdentifier",
+													"value": "{{Harness Parent Identifier}}"
+												}
+											],
+											"variable": [
+												{
+													"key": "Harness API Key Identifier",
+													"value": "exampleApiKeyId"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "x-api-key",
+											"value": "{{Harness_API_Token}}",
+											"description": ""
+										}
+									],
+									"cookie": [],
+									"body": "{\n  \"resource\": {\n    \"identifier\": \"exampleApiKeyId\",\n    \"name\": \"Example API Key\",\n    \"type\": \"SERVICE_ACCOUNT\",\n    \"parentIdentifier\": \"exampleServiceAccountId\",\n    \"apiKeyType\": \"SERVICE_ACCOUNT\",\n    \"created\": 1710000000000,\n    \"lastModified\": 1710000000000,\n    \"accountIdentifier\": \"exampleAccountId\",\n    \"enabled\": true,\n    \"description\": \"API Key for automation\",\n    \"tags\": [\"automation\", \"integration\"],\n    \"metadata\": {}\n  },\n  \"created\": 1710000000000,\n  \"correlationId\": \"example-correlation-id\",\n  \"metaData\": null,\n  \"status\": \"SUCCESS\"\n}"
+								}
+							]
 						},
 						{
 							"name": "List API Tokens",
@@ -1759,7 +3938,7 @@
 								"header": [
 									{
 										"key": "x-api-key",
-										"value": "{{Harness API Token}}",
+										"value": "{{Harness_API_Token}}",
 										"type": "text"
 									}
 								],
@@ -1773,9 +3952,9 @@
 									}
 								},
 								"url": {
-									"raw": "{{Harness API Base URL}}/token/aggregate?accountIdentifier={{Harness Account Identifier}}&apiKeyType={{Harness API Key Type}}&parentIdentifier={{Harness Parent Identifier}}&apiKeyIdentifier={{Harness API Key Identifier}}",
+									"raw": "{{Harness_API_Base_URL}}/token/aggregate?accountIdentifier={{Harness_Account_Identifier}}&apiKeyType={{Harness_API_Key_Type}}&parentIdentifier={{Harness_Parent_Identifier}}&apiKeyIdentifier={{Harness_API_Key_Identifier}}",
 									"host": [
-										"{{Harness API Base URL}}"
+										"{{Harness_API_Base_URL}}"
 									],
 									"path": [
 										"token",
@@ -1784,25 +3963,87 @@
 									"query": [
 										{
 											"key": "accountIdentifier",
-											"value": "{{Harness Account Identifier}}"
+											"value": "{{Harness_Account_Identifier}}"
 										},
 										{
 											"key": "apiKeyType",
-											"value": "{{Harness API Key Type}}"
+											"value": "{{Harness_API_Key_Type}}"
 										},
 										{
 											"key": "parentIdentifier",
-											"value": "{{Harness Parent Identifier}}"
+											"value": "{{Harness_Parent_Identifier}}"
 										},
 										{
 											"key": "apiKeyIdentifier",
-											"value": "{{Harness API Key Identifier}}"
+											"value": "{{Harness_API_Key_Identifier}}"
 										}
 									]
 								},
-								"description": "Docs link: [https://apidocs.harness.io/tag/Token#operation/listAggregatedTokens](https://apidocs.harness.io/tag/Token#operation/listAggregatedTokens)"
+								"description": "Docs link: [https://apidocs.harness.io/token/listaggregatedtokens](https://apidocs.harness.io/token/listaggregatedtokens)"
 							},
-							"response": []
+							"response": [
+								{
+									"name": "200 OK - List API Tokens Example",
+									"originalRequest": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "x-api-key",
+												"value": "{{Harness_API_Token}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{Harness_API_Base_URL}}/token/aggregate?accountIdentifier={{Harness_Account_Identifier}}&apiKeyType={{Harness_API_Key_Type}}&parentIdentifier={{Harness_Parent_Identifier}}&apiKeyIdentifier={{Harness_API_Key_Identifier}}",
+											"host": [
+												"{{Harness_API_Base_URL}}"
+											],
+											"path": [
+												"token",
+												"aggregate"
+											],
+											"query": [
+												{
+													"key": "accountIdentifier",
+													"value": "{{Harness Account Identifier}}"
+												},
+												{
+													"key": "apiKeyType",
+													"value": "{{Harness API Key Type}}"
+												},
+												{
+													"key": "parentIdentifier",
+													"value": "{{Harness Parent Identifier}}"
+												},
+												{
+													"key": "apiKeyIdentifier",
+													"value": "{{Harness API Key Identifier}}"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "x-api-key",
+											"value": "{{Harness_API_Token}}",
+											"description": ""
+										}
+									],
+									"cookie": [],
+									"body": "{\n  \"status\": \"SUCCESS\",\n  \"data\": [\n    {\n      \"identifier\": \"token_1234567890abcdef\",\n      \"apiKeyIdentifier\": \"apikey_abcdef1234567890\",\n      \"parentIdentifier\": \"serviceaccount_abcdef1234567890\",\n      \"name\": \"My API Token\",\n      \"type\": \"API_KEY\",\n      \"created\": \"2024-06-01T12:00:00Z\",\n      \"validTo\": \"2025-06-01T12:00:00Z\",\n      \"lastModified\": \"2024-06-01T12:00:00Z\",\n      \"expired\": false,\n      \"description\": \"Token for accessing project resources\"\n    }\n  ],\n  \"metaData\": {\n    \"page\": 0,\n    \"size\": 1,\n    \"total\": 1\n  },\n  \"correlationId\": \"abc123xyz\"\n}"
+								}
+							]
 						},
 						{
 							"name": "Delete API Key Permissions",
@@ -1811,7 +4052,7 @@
 								"header": [
 									{
 										"key": "x-api-key",
-										"value": "{{Harness API Token}}",
+										"value": "{{Harness_API_Token}}",
 										"type": "text"
 									}
 								],
@@ -1825,24 +4066,88 @@
 									}
 								},
 								"url": {
-									"raw": "{{Harness Auth Base URL}}/roleassignments/{{Harness Role Assignment Identifier}}?accountIdentifier={{Harness Account Identifier}}",
+									"raw": "{{Harness_Auth_Base_URL}}/roleassignments/{{Harness_Role_Assignment_Identifier}}?accountIdentifier={{Harness_Account_Identifier}}",
 									"host": [
-										"{{Harness Auth Base URL}}"
+										"{{Harness_Auth_Base_URL}}"
 									],
 									"path": [
 										"roleassignments",
-										"{{Harness Role Assignment Identifier}}"
+										"{{Harness_Role_Assignment_Identifier}}"
 									],
 									"query": [
 										{
 											"key": "accountIdentifier",
-											"value": "{{Harness Account Identifier}}"
+											"value": "{{Harness_Account_Identifier}}"
 										}
 									]
 								},
-								"description": "Docs link: [https://apidocs.harness.io/tag/Role-Assignments#operation/deleteRoleAssignment](https://apidocs.harness.io/tag/Role-Assignments#operation/deleteRoleAssignment)"
+								"description": "Docs link: [https://apidocs.harness.io/role-assignments/deleteroleassignment](https://apidocs.harness.io/role-assignments/deleteroleassignment)"
 							},
-							"response": []
+							"response": [
+								{
+									"name": "Successful Deletion (204 No Content)",
+									"originalRequest": {
+										"method": "DELETE",
+										"header": [
+											{
+												"key": "x-api-key",
+												"value": "{{Harness_API_Token}}",
+												"description": "Harness API authentication token"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{Harness_Auth_Base_URL}}/roleassignments/{{Harness_Role_Assignment_Identifier}}?accountIdentifier={{Harness_Account_Identifier}}",
+											"host": [
+												"{{Harness_Auth_Base_URL}}"
+											],
+											"path": [
+												"roleassignments",
+												"{{Harness_Role_Assignment_Identifier}}"
+											],
+											"query": [
+												{
+													"key": "accountIdentifier",
+													"value": "{{Harness Account Identifier}}",
+													"description": "Harness_Account_Identifier"
+												}
+											],
+											"variable": [
+												{
+													"key": "Harness Role Assignment Identifier",
+													"value": "<role_assignment_id>",
+													"description": "The identifier of the Harness role assignment to delete"
+												},
+												{
+													"key": "Harness Account Identifier",
+													"value": "<account_id>",
+													"description": "The Harness_Account_Identifier"
+												}
+											]
+										}
+									},
+									"status": "No Content",
+									"code": 204,
+									"_postman_previewlanguage": "text",
+									"header": [
+										{
+											"key": "x-api-key",
+											"value": "{{Harness_API_Token}}",
+											"description": "Harness API authentication token"
+										}
+									],
+									"cookie": [],
+									"body": "API key permissions deleted successfully. No content returned."
+								}
+							]
 						},
 						{
 							"name": "Delete a token",
@@ -1851,7 +4156,7 @@
 								"header": [
 									{
 										"key": "x-api-key",
-										"value": "{{Harness API Token}}",
+										"value": "{{Harness_API_Token}}",
 										"type": "text"
 									}
 								],
@@ -1865,36 +4170,98 @@
 									}
 								},
 								"url": {
-									"raw": "{{Harness API Base URL}}/token/{{Harness Token Identifier}}?accountIdentifier={{Harness Account Identifier}}&apiKeyType={{Harness API Key Type}}&parentIdentifier={{Harness Parent Identifier}}&apiKeyIdentifier={{Harness API Key Identifier}}",
+									"raw": "{{Harness_API_Base_URL}}/token/{{Harness_Token_Identifier}}?accountIdentifier={{Harness_Account_Identifier}}&apiKeyType={{Harness_API_Key_Type}}&parentIdentifier={{Harness_Parent_Identifier}}&apiKeyIdentifier={{Harness_API_Key_Identifier}}",
 									"host": [
-										"{{Harness API Base URL}}"
+										"{{Harness_API_Base_URL}}"
 									],
 									"path": [
 										"token",
-										"{{Harness Token Identifier}}"
+										"{{Harness_Token_Identifier}}"
 									],
 									"query": [
 										{
 											"key": "accountIdentifier",
-											"value": "{{Harness Account Identifier}}"
+											"value": "{{Harness_Account_Identifier}}"
 										},
 										{
 											"key": "apiKeyType",
-											"value": "{{Harness API Key Type}}"
+											"value": "{{Harness_API_Key_Type}}"
 										},
 										{
 											"key": "parentIdentifier",
-											"value": "{{Harness Parent Identifier}}"
+											"value": "{{Harness_Parent_Identifier}}"
 										},
 										{
 											"key": "apiKeyIdentifier",
-											"value": "{{Harness API Key Identifier}}"
+											"value": "{{Harness_API_Key_Identifier}}"
 										}
 									]
 								},
-								"description": "Docs link: [https://apidocs.harness.io/tag/Token#operation/deleteToken](https://apidocs.harness.io/tag/Token#operation/deleteToken)"
+								"description": "Docs link: [https://apidocs.harness.io/token/deletetoken](https://apidocs.harness.io/token/deletetoken)"
 							},
-							"response": []
+							"response": [
+								{
+									"name": "Successful Token Deletion",
+									"originalRequest": {
+										"method": "DELETE",
+										"header": [
+											{
+												"key": "x-api-key",
+												"value": "{{Harness_API_Token}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{Harness_API_Base_URL}}/token/{{Harness_Token_Identifier}}?accountIdentifier={{Harness_Account_Identifier}}&apiKeyType={{Harness_API_Key_Type}}&parentIdentifier={{Harness_Parent_Identifier}}&apiKeyIdentifier={{Harness_API_Key_Identifier}}",
+											"host": [
+												"{{Harness_API_Base_URL}}"
+											],
+											"path": [
+												"token",
+												"{{Harness_Token_Identifier}}"
+											],
+											"query": [
+												{
+													"key": "accountIdentifier",
+													"value": "{{Harness Account Identifier}}"
+												},
+												{
+													"key": "apiKeyType",
+													"value": "{{Harness API Key Type}}"
+												},
+												{
+													"key": "parentIdentifier",
+													"value": "{{Harness Parent Identifier}}"
+												},
+												{
+													"key": "apiKeyIdentifier",
+													"value": "{{Harness API Key Identifier}}"
+												}
+											]
+										}
+									},
+									"status": "No Content",
+									"code": 204,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "x-api-key",
+											"value": "{{Harness_API_Token}}",
+											"description": ""
+										}
+									],
+									"cookie": [],
+									"body": "{}"
+								}
+							]
 						},
 						{
 							"name": "Delete API Key",
@@ -1903,7 +4270,7 @@
 								"header": [
 									{
 										"key": "x-api-key",
-										"value": "{{Harness API Token}}",
+										"value": "{{Harness_API_Token}}",
 										"type": "text"
 									}
 								],
@@ -1917,32 +4284,96 @@
 									}
 								},
 								"url": {
-									"raw": "{{Harness API Base URL}}/apikey/{{Harness API Key Identifier}}?accountIdentifier={{Harness Account Identifier}}&apiKeyType={{Harness API Key Type}}&parentIdentifier={{Harness Parent Identifier}}",
+									"raw": "{{Harness_API_Base_URL}}/apikey/{{Harness_API_Key_Identifier}}?accountIdentifier={{Harness_Account_Identifier}}&apiKeyType={{Harness_API_Key_Type}}&parentIdentifier={{Harness_Parent_Identifier}}",
 									"host": [
-										"{{Harness API Base URL}}"
+										"{{Harness_API_Base_URL}}"
 									],
 									"path": [
 										"apikey",
-										"{{Harness API Key Identifier}}"
+										"{{Harness_API_Key_Identifier}}"
 									],
 									"query": [
 										{
 											"key": "accountIdentifier",
-											"value": "{{Harness Account Identifier}}"
+											"value": "{{Harness_Account_Identifier}}"
 										},
 										{
 											"key": "apiKeyType",
-											"value": "{{Harness API Key Type}}"
+											"value": "{{Harness_API_Key_Type}}"
 										},
 										{
 											"key": "parentIdentifier",
-											"value": "{{Harness Parent Identifier}}"
+											"value": "{{Harness_Parent_Identifier}}"
 										}
 									]
 								},
-								"description": "Docs link: [https://apidocs.harness.io/tag/ApiKey#operation/deleteApiKey](https://apidocs.harness.io/tag/ApiKey#operation/deleteApiKey)"
+								"description": "Docs link: [https://apidocs.harness.io/apikey/deleteapikey](https://apidocs.harness.io/apikey/deleteapikey)"
 							},
-							"response": []
+							"response": [
+								{
+									"name": "Successful Deletion (204 No Content)",
+									"originalRequest": {
+										"method": "DELETE",
+										"header": [
+											{
+												"key": "x-api-key",
+												"value": "{{Harness_API_Token}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{Harness_API_Base_URL}}/apikey/{{Harness_API_Key_Identifier}}?accountIdentifier={{Harness_Account_Identifier}}&apiKeyType={{Harness_API_Key_Type}}&parentIdentifier={{Harness_Parent_Identifier}}",
+											"host": [
+												"{{Harness_API_Base_URL}}"
+											],
+											"path": [
+												"apikey",
+												"{{Harness_API_Key_Identifier}}"
+											],
+											"query": [
+												{
+													"key": "accountIdentifier",
+													"value": "{{Harness Account Identifier}}"
+												},
+												{
+													"key": "apiKeyType",
+													"value": "{{Harness API Key Type}}"
+												},
+												{
+													"key": "parentIdentifier",
+													"value": "{{Harness Parent Identifier}}"
+												}
+											],
+											"variable": [
+												{
+													"key": "Harness API Key Identifier",
+													"value": "<api-key-id>"
+												}
+											]
+										}
+									},
+									"status": "No Content",
+									"code": 204,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "x-api-key",
+											"value": "{{Harness_API_Token}}",
+											"description": ""
+										}
+									],
+									"cookie": [],
+									"body": "{}"
+								}
+							]
 						},
 						{
 							"name": "Delete Service Account",
@@ -1951,7 +4382,7 @@
 								"header": [
 									{
 										"key": "x-api-key",
-										"value": "{{Harness API Token}}",
+										"value": "{{Harness_API_Token}}",
 										"type": "text"
 									}
 								],
@@ -1965,24 +4396,74 @@
 									}
 								},
 								"url": {
-									"raw": "{{Harness API Base URL}}/serviceaccount/{{Harness Service Account Identifier}}?accountIdentifier={{Harness Account Identifier}}",
+									"raw": "{{Harness_API_Base_URL}}/serviceaccount/{{Harness_Service_Account_Identifier}}?accountIdentifier={{Harness_Account_Identifier}}",
 									"host": [
-										"{{Harness API Base URL}}"
+										"{{Harness_API_Base_URL}}"
 									],
 									"path": [
 										"serviceaccount",
-										"{{Harness Service Account Identifier}}"
+										"{{Harness_Service_Account_Identifier}}"
 									],
 									"query": [
 										{
 											"key": "accountIdentifier",
-											"value": "{{Harness Account Identifier}}"
+											"value": "{{Harness_Account_Identifier}}"
 										}
 									]
 								},
-								"description": "Docs link: [https://apidocs.harness.io/tag/Service-Account#operation/deleteServiceAccount](https://apidocs.harness.io/tag/Service-Account#operation/deleteServiceAccount)"
+								"description": "Docs link: [https://apidocs.harness.io/service-account/deleteserviceaccount](https://apidocs.harness.io/service-account/deleteserviceaccount)"
 							},
-							"response": []
+							"response": [
+								{
+									"name": "Successful Deletion (204 No Content)",
+									"originalRequest": {
+										"method": "DELETE",
+										"header": [
+											{
+												"key": "x-api-key",
+												"value": "{{Harness_API_Token}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{Harness_API_Base_URL}}/serviceaccount/{{Harness_Service_Account_Identifier}}?accountIdentifier={{Harness_Account_Identifier}}",
+											"host": [
+												"{{Harness_API_Base_URL}}"
+											],
+											"path": [
+												"serviceaccount",
+												"{{Harness_Service_Account_Identifier}}"
+											],
+											"query": [
+												{
+													"key": "accountIdentifier",
+													"value": "{{Harness Account Identifier}}"
+												}
+											]
+										}
+									},
+									"status": "No Content",
+									"code": 204,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "x-api-key",
+											"value": "{{Harness_API_Token}}",
+											"description": ""
+										}
+									],
+									"cookie": [],
+									"body": "{}"
+								}
+							]
 						}
 					],
 					"description": "The `/serviceaccount`, `/apikey`, `/token`, and `/roleassignments` endpoints here replace the Split `/apiKeys` endpoint after migration to Harness.\n\nHere are the **Harness API equivalents** for replacing the **Split API key creation process**, which now requires **three components**:\n\n1. **Service Account**\n    \n2. **API Key**\n    \n3. **Token**\n    \n\n---\n\n## **Step 1: Create a Service Account**\n\nBefore creating an API key, you must first create a **Service Account** since API keys are scoped under a **Service Account**.\n\n👉 **Save the** **`identifier`** **from the response to use in the next step as** `SERVICE_ACCOUNT_ID`\n\n---\n\n## **Step 2: Create an API Key**\n\nNow that the Service Account is created, you can generate an **API Key**.\n\n👉 **Save the** **`identifier`** **from the response to use in the next step as** `API_KEY_ID`\n\n---\n\n## **Step 3: Create a Token for the API Key**\n\nFinally, you need to create a **Token** to use with the API Key.\n\n👉 **Save the** **`token`** **value to use in API calls as the bearer token.**\n\n---\n\n# More Details on Harness API Key Structure\n\n## Service Account > API Key > Token\n\nWhile Split Admin API keys were a single entity, in Harness they consist of three entities at different levels for greater control.\n\n## **1\\. Service Account Level**\n\n- **Primary Role:** Defines **who** (a machine identity) is making API requests.\n    \n- **What Can Be Set Here?**\n    \n    - **Permissions & Roles**: Permissions are assigned at the **Service Account level**, not at the API Key or Token level.\n        \n    - **Scope**: A Service Account can be scoped at **Account, Organization, or Project level**.\n        \n    - **Ownership of API Keys**: Each API Key is linked to a specific **Service Account**.\n        \n- **Key Takeaway:** **Permissions are set at the Service Account level, and all API Keys created under it inherit these permissions.**\n    \n\n## **2\\. API Key Level**\n\n- **Primary Role:** Acts as an **access credential** tied to a Service Account.\n    \n- **What Can Be Set Here?**\n    \n    - **Scope**: An API Key belongs to a specific **Service Account**, meaning it has the same permissions.\n        \n    - **Token Generation**: Each API Key can have multiple **Tokens** for authentication.\n        \n    - **Expiry Control**: API Keys **do not expire** unless explicitly deleted.\n        \n- **Key Takeaway:** **API Keys provide authentication, but they do not define permissions themselves.**\n    \n\n## **3\\. Token Level**\n\n- **Primary Role:** A short-lived, displayed-once **credential** used to authenticate requests.\n    \n- **What Can Be Set Here?**\n    \n    - **Expiration Date**: Tokens can have an **expiration time** (or be permanent).\n        \n    - **One-Time Visibility**: A token is **only shown once** when created.\n        \n    - **Rotatable**: Tokens can be **revoked and rotated** without affecting the API Key.\n        \n- **Key Takeaway:** **Tokens are temporary authentication mechanisms derived from API Keys. They enable secure, limited-time API access.**\n    \n\n### **Summary: How They Work Together**\n\n| **Level** | **Purpose** | **What Can Be Set Here?** |\n| --- | --- | --- |\n| **Service Account** | Defines identity & permissions | **Roles, permissions, and scope** (Account/Org/Project) |\n| **API Key** | Authentication credential | **Scoped to a Service Account** (inherits permissions) |\n| **Token** | Temporary authentication | **Expiration, rotation, and single-use access** |",
@@ -1991,7 +4472,7 @@
 						"apikey": [
 							{
 								"key": "value",
-								"value": "{{Harness API Token}}",
+								"value": "{{Harness_API_Token}}",
 								"type": "string"
 							},
 							{
@@ -2039,9 +4520,9 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "{{Split API Base URL}}/restrictions?resource_type={{Split Resource Type}}&resource_id={{Split Resource Identifier}}",
+									"raw": "{{Split_API_Base_URL}}/restrictions?resource_type={{Split_Resource_Type}}&resource_id={{Split_Resource_Identifier}}",
 									"host": [
-										"{{Split API Base URL}}"
+										"{{Split_API_Base_URL}}"
 									],
 									"path": [
 										"restrictions"
@@ -2049,11 +4530,11 @@
 									"query": [
 										{
 											"key": "resource_type",
-											"value": "{{Split Resource Type}}"
+											"value": "{{Split_Resource_Type}}"
 										},
 										{
 											"key": "resource_id",
-											"value": "{{Split Resource Identifier}}"
+											"value": "{{Split_Resource_Identifier}}"
 										},
 										{
 											"key": "offset",
@@ -2066,9 +4547,57 @@
 											"disabled": true
 										}
 									]
-								}
+								},
+								"description": "**Legacy Split API doc link:** [https://docs.split.io/reference/list-restrictions](https://docs.split.io/reference/list-restrictions)"
 							},
-							"response": []
+							"response": [
+								{
+									"name": "200 OK - List Restrictions Example",
+									"originalRequest": {
+										"method": "GET",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"url": {
+											"raw": "{{Split_API_Base_URL}}/restrictions?resource_type={{Split_Resource_Type}}&resource_id={{Split_Resource_Identifier}}",
+											"host": [
+												"{{Split_API_Base_URL}}"
+											],
+											"path": [
+												"restrictions"
+											],
+											"query": [
+												{
+													"key": "resource_type",
+													"value": "{{Split Resource Type}}"
+												},
+												{
+													"key": "resource_id",
+													"value": "{{Split Resource Identifier}}"
+												},
+												{
+													"key": "offset",
+													"value": "",
+													"disabled": true
+												},
+												{
+													"key": "limit",
+													"value": "",
+													"disabled": true
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [],
+									"cookie": [],
+									"body": "{\n  \"resource_type\": \"workspace\",\n  \"resource_id\": \"abc123\",\n  \"restrictions\": [\n    {\n      \"subject_type\": \"user\",\n      \"subject_id\": \"user_1\",\n      \"permissions\": [\"view\"]\n    },\n    {\n      \"subject_type\": \"group\",\n      \"subject_id\": \"admins\",\n      \"permissions\": [\"view\"]\n    }\n  ]\n}"
+								}
+							]
 						},
 						{
 							"name": "Update Restrictions",
@@ -2091,9 +4620,9 @@
 									}
 								},
 								"url": {
-									"raw": "{{Split API Base URL}}/restrictions",
+									"raw": "{{Split_API_Base_URL}}/restrictions",
 									"host": [
-										"{{Split API Base URL}}"
+										"{{Split_API_Base_URL}}"
 									],
 									"path": [
 										"restrictions"
@@ -2105,9 +4634,60 @@
 											"disabled": true
 										}
 									]
-								}
+								},
+								"description": "**Legacy Split API doc link:** [https://docs.split.io/reference/update-restrictions](https://docs.split.io/reference/update-restrictions)"
 							},
-							"response": []
+							"response": [
+								{
+									"name": "Success - Restrictions Updated",
+									"originalRequest": {
+										"method": "PUT",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n    \"resource\": {\n        \"type\": \"workspace\",\n        \"id\": \"62eb1d50-046f-11ed-8301-22b32ea1d986\"\n    },\n    \"operations\": {\n        \"view\": true\n    },\n    \"resourcePermissions\": {\n        \"view\": [\n            {\n                \"type\": \"group\",\n                \"id\": \"e8613b00-abd6-11ec-9dd7-4e682933ca7c\"\n            },\n            {\n                \"type\": \"group\",\n                \"id\": \"72aae840-4c84-11ec-88a1-fe92fe968329\"\n            }\n        ]\n    }\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{Split_API_Base_URL}}/restrictions",
+											"host": [
+												"{{Split_API_Base_URL}}"
+											],
+											"path": [
+												"restrictions"
+											],
+											"query": [
+												{
+													"key": "dry_run",
+													"value": "",
+													"disabled": true
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json",
+											"description": ""
+										}
+									],
+									"cookie": [],
+									"body": "{\n  \"message\": \"Restrictions updated successfully.\",\n  \"resource\": {\n    \"type\": \"workspace\",\n    \"id\": \"62eb1d50-046f-11ed-8301-22b32ea1d986\"\n  },\n  \"operations\": {\n    \"view\": true\n  },\n  \"resourcePermissions\": {\n    \"view\": [\n      {\n        \"type\": \"group\",\n        \"id\": \"e8613b00-abd6-11ec-9dd7-4e682933ca7c\"\n      },\n      {\n        \"type\": \"group\",\n        \"id\": \"72aae840-4c84-11ec-88a1-fe92fe968329\"\n      }\n    ]\n  }\n}"
+								}
+							]
 						}
 					],
 					"description": "The `/restrictions` endpoint becomes unavailable to you once your account has been migrated to Harness.\n\nThis endpoint is used in Split for managing view restrictions on a project.\n\nPlease see the more detailed overview in the this folder's parent folder.",
@@ -2116,7 +4696,7 @@
 						"bearer": [
 							{
 								"key": "token",
-								"value": "{{Split API Token}}",
+								"value": "{{Split_API_Token}}",
 								"type": "string"
 							}
 						]
@@ -2154,7 +4734,7 @@
 								"header": [
 									{
 										"key": "x-api-key",
-										"value": "{{Harness API Token}}",
+										"value": "{{Harness_API_Token}}",
 										"type": "text"
 									}
 								],
@@ -2168,9 +4748,9 @@
 									}
 								},
 								"url": {
-									"raw": "{{Harness Auth Base URL}}/roleassignments?accountIdentifier={{Harness Account Identifier}}",
+									"raw": "{{Harness_Auth_Base_URL}}/roleassignments?accountIdentifier={{Harness_Account_Identifier}}",
 									"host": [
-										"{{Harness Auth Base URL}}"
+										"{{Harness_Auth_Base_URL}}"
 									],
 									"path": [
 										"roleassignments"
@@ -2178,13 +4758,62 @@
 									"query": [
 										{
 											"key": "accountIdentifier",
-											"value": "{{Harness Account Identifier}}"
+											"value": "{{Harness_Account_Identifier}}"
 										}
 									]
 								},
-								"description": "Docs link: [https://apidocs.harness.io/tag/Role-Assignments#operation/postRoleAssignments](https://apidocs.harness.io/tag/Role-Assignments#operation/postRoleAssignments)"
+								"description": "Docs link: [https://apidocs.harness.io/role-assignments/postroleassignments](https://apidocs.harness.io/role-assignments/postroleassignments)"
 							},
-							"response": []
+							"response": [
+								{
+									"name": "Successful Role Assignment Creation",
+									"originalRequest": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "x-api-key",
+												"value": "{{Harness_API_Token}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n  \"identifier\": \"example_role_assignment2\",\n  \"resourceGroupIdentifier\": \"_all_account_level_resources\",\n  \"roleIdentifier\": \"_account_admin\",\n  \"roleReference\": {\n    \"identifier\": \"_account_admin\",\n    \"scopeLevel\": \"ACCOUNT\"\n  },\n  \"principal\": {\n    \"scope\": \"ACCOUNT\",\n    \"identifier\": \"test_service_account\",\n    \"type\": \"SERVICE_ACCOUNT\"\n  },\n  \"disabled\": false,\n  \"managed\": false,\n  \"internal\": false\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{Harness_Auth_Base_URL}}/roleassignments?accountIdentifier={{Harness_Account_Identifier}}",
+											"host": [
+												"{{Harness_Auth_Base_URL}}"
+											],
+											"path": [
+												"roleassignments"
+											],
+											"query": [
+												{
+													"key": "accountIdentifier",
+													"value": "{{Harness Account Identifier}}"
+												}
+											]
+										}
+									},
+									"status": "Created",
+									"code": 201,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "x-api-key",
+											"value": "{{Harness_API_Token}}",
+											"description": ""
+										}
+									],
+									"cookie": [],
+									"body": "{\n  \"status\": \"SUCCESS\",\n  \"roleAssignment\": {\n    \"identifier\": \"example_role_assignment2\",\n    \"resourceGroupIdentifier\": \"_all_account_level_resources\",\n    \"roleIdentifier\": \"_account_admin\",\n    \"roleReference\": {\n      \"identifier\": \"_account_admin\",\n      \"scopeLevel\": \"ACCOUNT\"\n    },\n    \"principal\": {\n      \"scope\": \"ACCOUNT\",\n      \"identifier\": \"test_service_account\",\n      \"type\": \"SERVICE_ACCOUNT\"\n    },\n    \"disabled\": false,\n    \"managed\": false,\n    \"internal\": false\n  }\n}"
+								}
+							]
 						},
 						{
 							"name": "List role assignments",
@@ -2196,7 +4825,7 @@
 								"header": [
 									{
 										"key": "x-api-key",
-										"value": "{{Harness API Token}}",
+										"value": "{{Harness_API_Token}}",
 										"type": "text"
 									}
 								],
@@ -2210,9 +4839,9 @@
 									}
 								},
 								"url": {
-									"raw": "{{Harness Auth Base URL}}/roleassignments?accountIdentifier={{Harness Account Identifier}}",
+									"raw": "{{Harness_Auth_Base_URL}}/roleassignments?accountIdentifier={{Harness_Account_Identifier}}",
 									"host": [
-										"{{Harness Auth Base URL}}"
+										"{{Harness_Auth_Base_URL}}"
 									],
 									"path": [
 										"roleassignments"
@@ -2220,13 +4849,62 @@
 									"query": [
 										{
 											"key": "accountIdentifier",
-											"value": "{{Harness Account Identifier}}"
+											"value": "{{Harness_Account_Identifier}}"
 										}
 									]
 								},
-								"description": "Docs link: [https://apidocs.harness.io/tag/Role-Assignments#operation/getRoleAssignmentList](https://apidocs.harness.io/tag/Role-Assignments#operation/getRoleAssignmentList)"
+								"description": "Docs link: [https://apidocs.harness.io/role-assignments/getroleassignmentlist](https://apidocs.harness.io/role-assignments/getroleassignmentlist)"
 							},
-							"response": []
+							"response": [
+								{
+									"name": "Successful Role Assignments List",
+									"originalRequest": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "x-api-key",
+												"value": "{{Harness_API_Token}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{Harness_Auth_Base_URL}}/roleassignments?accountIdentifier={{Harness_Account_Identifier}}",
+											"host": [
+												"{{Harness_Auth_Base_URL}}"
+											],
+											"path": [
+												"roleassignments"
+											],
+											"query": [
+												{
+													"key": "accountIdentifier",
+													"value": "{{Harness Account Identifier}}"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "x-api-key",
+											"value": "{{Harness_API_Token}}",
+											"description": ""
+										}
+									],
+									"cookie": [],
+									"body": "{\n  \"status\": \"SUCCESS\",\n  \"roleAssignments\": [\n    {\n      \"identifier\": \"roleAssignment1\",\n      \"role\": \"project_viewer\",\n      \"resourceGroup\": \"_fme_all_resources\",\n      \"principal\": {\n        \"type\": \"USER\",\n        \"identifier\": \"user1@example.com\"\n      },\n      \"scope\": \"project\"\n    },\n    {\n      \"identifier\": \"roleAssignment2\",\n      \"role\": \"fme_manager\",\n      \"resourceGroup\": \"_fme_all_resources\",\n      \"principal\": {\n        \"type\": \"USER_GROUP\",\n        \"identifier\": \"EnablementGroup\"\n      },\n      \"scope\": \"account\"\n    }\n  ]\n}"
+								}
+							]
 						},
 						{
 							"name": "Delete Role Assignment",
@@ -2235,7 +4913,7 @@
 								"header": [
 									{
 										"key": "x-api-key",
-										"value": "{{Harness API Token}}",
+										"value": "{{Harness_API_Token}}",
 										"type": "text"
 									}
 								],
@@ -2249,24 +4927,80 @@
 									}
 								},
 								"url": {
-									"raw": "{{Harness Auth Base URL}}/roleassignments/{{Harness Role Assignment Identifier}}?accountIdentifier={{Harness Account Identifier}}",
+									"raw": "{{Harness_Auth_Base_URL}}/roleassignments/{{Harness_Role_Assignment_Identifier}}?accountIdentifier={{Harness_Account_Identifier}}",
 									"host": [
-										"{{Harness Auth Base URL}}"
+										"{{Harness_Auth_Base_URL}}"
 									],
 									"path": [
 										"roleassignments",
-										"{{Harness Role Assignment Identifier}}"
+										"{{Harness_Role_Assignment_Identifier}}"
 									],
 									"query": [
 										{
 											"key": "accountIdentifier",
-											"value": "{{Harness Account Identifier}}"
+											"value": "{{Harness_Account_Identifier}}"
 										}
 									]
 								},
-								"description": "Docs link: [https://apidocs.harness.io/tag/Role-Assignments#operation/deleteRoleAssignment](https://apidocs.harness.io/tag/Role-Assignments#operation/deleteRoleAssignment)"
+								"description": "Docs link: [https://apidocs.harness.io/role-assignments/deleteroleassignment](https://apidocs.harness.io/role-assignments/deleteroleassignment)"
 							},
-							"response": []
+							"response": [
+								{
+									"name": "Successful Deletion",
+									"originalRequest": {
+										"method": "DELETE",
+										"header": [
+											{
+												"key": "x-api-key",
+												"value": "{{Harness_API_Token}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{Harness_Auth_Base_URL}}/roleassignments/{{Harness_Role_Assignment_Identifier}}?accountIdentifier={{Harness_Account_Identifier}}",
+											"host": [
+												"{{Harness_Auth_Base_URL}}"
+											],
+											"path": [
+												"roleassignments",
+												"{{Harness_Role_Assignment_Identifier}}"
+											],
+											"query": [
+												{
+													"key": "accountIdentifier",
+													"value": "{{Harness Account Identifier}}"
+												}
+											],
+											"variable": [
+												{
+													"key": "Harness Role Assignment Identifier",
+													"value": "<roleAssignmentId>"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "x-api-key",
+											"value": "{{Harness_API_Token}}",
+											"description": ""
+										}
+									],
+									"cookie": [],
+									"body": "{\n  \"status\": \"SUCCESS\",\n  \"message\": \"Role assignment deleted successfully.\"\n}"
+								}
+							]
 						},
 						{
 							"name": "Create Role",
@@ -2275,7 +5009,7 @@
 								"header": [
 									{
 										"key": "x-api-key",
-										"value": "{{Harness API Token}}",
+										"value": "{{Harness_API_Token}}",
 										"type": "text"
 									}
 								],
@@ -2289,9 +5023,9 @@
 									}
 								},
 								"url": {
-									"raw": "{{Harness Auth Base URL}}/roles?accountIdentifier={{Harness Account Identifier}}",
+									"raw": "{{Harness_Auth_Base_URL}}/roles?accountIdentifier={{Harness_Account_Identifier}}",
 									"host": [
-										"{{Harness Auth Base URL}}"
+										"{{Harness_Auth_Base_URL}}"
 									],
 									"path": [
 										"roles"
@@ -2299,13 +5033,62 @@
 									"query": [
 										{
 											"key": "accountIdentifier",
-											"value": "{{Harness Account Identifier}}"
+											"value": "{{Harness_Account_Identifier}}"
 										}
 									]
 								},
-								"description": "Docs link: [https://apidocs.harness.io/tag/Roles#operation/postRole](https://apidocs.harness.io/tag/Roles#operation/postRole)"
+								"description": "Docs link: [https://apidocs.harness.io/roles/postrole](https://apidocs.harness.io/roles/postrole)"
 							},
-							"response": []
+							"response": [
+								{
+									"name": "Successful Role Creation (201 Created)",
+									"originalRequest": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "x-api-key",
+												"value": "{{Harness_API_Token}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n  \"identifier\": \"test_role\",\n  \"name\": \"test role\",\n  \"permissions\": [\n    \"fme_fmefeatureflag_edit\",\n    \"fme_fmeenvironment_view\"\n  ],\n  \"allowedScopeLevels\": [\n    \"account\"\n  ]\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{Harness_Auth_Base_URL}}/roles?accountIdentifier={{Harness_Account_Identifier}}",
+											"host": [
+												"{{Harness_Auth_Base_URL}}"
+											],
+											"path": [
+												"roles"
+											],
+											"query": [
+												{
+													"key": "accountIdentifier",
+													"value": "{{Harness Account Identifier}}"
+												}
+											]
+										}
+									},
+									"status": "Created",
+									"code": 201,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "x-api-key",
+											"value": "{{Harness_API_Token}}",
+											"description": ""
+										}
+									],
+									"cookie": [],
+									"body": "{\n  \"role\": {\n    \"identifier\": \"test_role\",\n    \"name\": \"test role\",\n    \"permissions\": [\n      \"fme_fmefeatureflag_edit\",\n      \"fme_fmeenvironment_view\"\n    ],\n    \"allowedScopeLevels\": [\n      \"account\"\n    ]\n  },\n  \"created\": true,\n  \"message\": \"Role created successfully.\"\n}"
+								}
+							]
 						},
 						{
 							"name": "Update Role",
@@ -2314,7 +5097,7 @@
 								"header": [
 									{
 										"key": "x-api-key",
-										"value": "{{Harness API Token}}",
+										"value": "{{Harness_API_Token}}",
 										"type": "text"
 									}
 								],
@@ -2328,24 +5111,80 @@
 									}
 								},
 								"url": {
-									"raw": "{{Harness Auth Base URL}}/roles/{{Harness Role Identifier}}?accountIdentifier={{Harness Account Identifier}}",
+									"raw": "{{Harness_Auth_Base_URL}}/roles/{{Harness_Role_Identifier}}?accountIdentifier={{Harness_Account_Identifier}}",
 									"host": [
-										"{{Harness Auth Base URL}}"
+										"{{Harness_Auth_Base_URL}}"
 									],
 									"path": [
 										"roles",
-										"{{Harness Role Identifier}}"
+										"{{Harness_Role_Identifier}}"
 									],
 									"query": [
 										{
 											"key": "accountIdentifier",
-											"value": "{{Harness Account Identifier}}"
+											"value": "{{Harness_Account_Identifier}}"
 										}
 									]
 								},
-								"description": "Docs link: [https://apidocs.harness.io/tag/Roles#operation/putRole](https://apidocs.harness.io/tag/Roles#operation/putRole)"
+								"description": "Docs link: [https://apidocs.harness.io/roles/putrole](https://apidocs.harness.io/roles/putrole)"
 							},
-							"response": []
+							"response": [
+								{
+									"name": "Successful Role Update",
+									"originalRequest": {
+										"method": "PUT",
+										"header": [
+											{
+												"key": "x-api-key",
+												"value": "{{Harness_API_Token}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n  \"identifier\": \"test_role\",\n  \"name\": \"test role updated\",\n  \"permissions\": [\n    \"fme_fmefeatureflag_edit\",\n    \"fme_fmeenvironment_view\",\n    \"core_usergroup_view\"\n  ],\n  \"allowedScopeLevels\": [\n    \"account\"\n  ]\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{Harness_Auth_Base_URL}}/roles/{{Harness_Role_Identifier}}?accountIdentifier={{Harness_Account_Identifier}}",
+											"host": [
+												"{{Harness_Auth_Base_URL}}"
+											],
+											"path": [
+												"roles",
+												"{{Harness_Role_Identifier}}"
+											],
+											"query": [
+												{
+													"key": "accountIdentifier",
+													"value": "{{Harness Account Identifier}}"
+												}
+											],
+											"variable": [
+												{
+													"key": "Harness Role Identifier",
+													"value": "{{Harness_Role_Identifier}}"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "x-api-key",
+											"value": "{{Harness_API_Token}}",
+											"description": ""
+										}
+									],
+									"cookie": [],
+									"body": "{\n  \"status\": \"SUCCESS\",\n  \"message\": \"Role updated successfully.\",\n  \"role\": {\n    \"identifier\": \"test_role\",\n    \"name\": \"test role updated\",\n    \"permissions\": [\n      \"fme_fmefeatureflag_edit\",\n      \"fme_fmeenvironment_view\",\n      \"core_usergroup_view\"\n    ],\n    \"allowedScopeLevels\": [\n      \"account\"\n    ]\n  }\n}"
+								}
+							]
 						},
 						{
 							"name": "List roles",
@@ -2357,7 +5196,7 @@
 								"header": [
 									{
 										"key": "x-api-key",
-										"value": "{{Harness API Token}}",
+										"value": "{{Harness_API_Token}}",
 										"type": "text"
 									}
 								],
@@ -2371,9 +5210,9 @@
 									}
 								},
 								"url": {
-									"raw": "{{Harness Auth Base URL}}/roles?accountIdentifier={{Harness Account Identifier}}",
+									"raw": "{{Harness_Auth_Base_URL}}/roles?accountIdentifier={{Harness_Account_Identifier}}",
 									"host": [
-										"{{Harness Auth Base URL}}"
+										"{{Harness_Auth_Base_URL}}"
 									],
 									"path": [
 										"roles"
@@ -2381,13 +5220,62 @@
 									"query": [
 										{
 											"key": "accountIdentifier",
-											"value": "{{Harness Account Identifier}}"
+											"value": "{{Harness_Account_Identifier}}"
 										}
 									]
 								},
-								"description": "Docs link: [https://apidocs.harness.io/tag/Roles#operation/getRoleList](https://apidocs.harness.io/tag/Roles#operation/getRoleList)"
+								"description": "Docs link: [https://apidocs.harness.io/roles/getrolelist](https://apidocs.harness.io/roles/getrolelist)"
 							},
-							"response": []
+							"response": [
+								{
+									"name": "200 OK - List of Roles",
+									"originalRequest": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "x-api-key",
+												"value": "{{Harness_API_Token}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{Harness_Auth_Base_URL}}/roles?accountIdentifier={{Harness_Account_Identifier}}",
+											"host": [
+												"{{Harness_Auth_Base_URL}}"
+											],
+											"path": [
+												"roles"
+											],
+											"query": [
+												{
+													"key": "accountIdentifier",
+													"value": "{{Harness Account Identifier}}"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "x-api-key",
+											"value": "{{Harness_API_Token}}",
+											"description": ""
+										}
+									],
+									"cookie": [],
+									"body": "{\n  \"status\": \"SUCCESS\",\n  \"data\": {\n    \"content\": [\n      {\n        \"identifier\": \"project_viewer\",\n        \"name\": \"Project Viewer\",\n        \"description\": \"Read-only access to project resources.\",\n        \"allowedScopeLevels\": [\"project\"],\n        \"permissions\": [\n          \"core_project_view\",\n          \"core_resourcegroup_view\"\n        ]\n      },\n      {\n        \"identifier\": \"fme_manager\",\n        \"name\": \"FME Manager\",\n        \"description\": \"Full management access for FME projects.\",\n        \"allowedScopeLevels\": [\"project\"],\n        \"permissions\": [\n          \"core_project_edit\",\n          \"core_resourcegroup_manage\"\n        ]\n      }\n    ],\n    \"pageIndex\": 0,\n    \"pageSize\": 20,\n    \"totalItems\": 2,\n    \"totalPages\": 1\n  },\n  \"metaData\": null,\n  \"correlationId\": \"string\"\n}"
+								}
+							]
 						},
 						{
 							"name": "Delete Role",
@@ -2396,7 +5284,7 @@
 								"header": [
 									{
 										"key": "x-api-key",
-										"value": "{{Harness API Token}}",
+										"value": "{{Harness_API_Token}}",
 										"type": "text"
 									}
 								],
@@ -2410,24 +5298,88 @@
 									}
 								},
 								"url": {
-									"raw": "{{Harness Auth Base URL}}/roles/{{Harness Role Identifier}}?accountIdentifier={{Harness Account Identifier}}",
+									"raw": "{{Harness_Auth_Base_URL}}/roles/{{Harness_Role_Identifier}}?accountIdentifier={{Harness_Account_Identifier}}",
 									"host": [
-										"{{Harness Auth Base URL}}"
+										"{{Harness_Auth_Base_URL}}"
 									],
 									"path": [
 										"roles",
-										"{{Harness Role Identifier}}"
+										"{{Harness_Role_Identifier}}"
 									],
 									"query": [
 										{
 											"key": "accountIdentifier",
-											"value": "{{Harness Account Identifier}}"
+											"value": "{{Harness_Account_Identifier}}"
 										}
 									]
 								},
-								"description": "Docs link: [https://apidocs.harness.io/tag/Roles#operation/deleteRole](https://apidocs.harness.io/tag/Roles#operation/deleteRole)"
+								"description": "Docs link: [https://apidocs.harness.io/roles/deleterole](https://apidocs.harness.io/roles/deleterole)"
 							},
-							"response": []
+							"response": [
+								{
+									"name": "Successful Role Deletion (204 No Content)",
+									"originalRequest": {
+										"method": "DELETE",
+										"header": [
+											{
+												"key": "x-api-key",
+												"value": "{{Harness_API_Token}}",
+												"description": "Harness API authentication token"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{Harness_Auth_Base_URL}}/roles/{{Harness_Role_Identifier}}?accountIdentifier={{Harness_Account_Identifier}}",
+											"host": [
+												"{{Harness_Auth_Base_URL}}"
+											],
+											"path": [
+												"roles",
+												"{{Harness_Role_Identifier}}"
+											],
+											"query": [
+												{
+													"key": "accountIdentifier",
+													"value": "{{Harness Account Identifier}}",
+													"description": "Harness_Account_Identifier"
+												}
+											],
+											"variable": [
+												{
+													"key": "Harness Role Identifier",
+													"value": "<role_id>",
+													"description": "The identifier of the Harness role to delete"
+												},
+												{
+													"key": "Harness Account Identifier",
+													"value": "<account_id>",
+													"description": "The Harness_Account_Identifier"
+												}
+											]
+										}
+									},
+									"status": "No Content",
+									"code": 204,
+									"_postman_previewlanguage": "text",
+									"header": [
+										{
+											"key": "x-api-key",
+											"value": "{{Harness_API_Token}}",
+											"description": "Harness API authentication token"
+										}
+									],
+									"cookie": [],
+									"body": "Role deleted successfully. No content returned."
+								}
+							]
 						},
 						{
 							"name": "Create Resource Group",
@@ -2436,13 +5388,13 @@
 								"header": [
 									{
 										"key": "x-api-key",
-										"value": "{{Harness API Token}}",
+										"value": "{{Harness_API_Token}}",
 										"type": "text"
 									}
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n  \"resourceGroup\": {\n    \"accountIdentifier\": \"{{Harness Account Identifier}}\",\n    // \"orgIdentifier\": \"string\",\n    // \"projectIdentifier\": \"string\",\n    \"identifier\": \"test_resource_group\",\n    \"name\": \"test resource group\"\n    // \"color\": \"string\",\n    // \"tags\": {\n    //   \"property1\": \"string\",\n    //   \"property2\": \"string\"\n    // },\n    // \"description\": \"string\",\n    // \"allowedScopeLevels\": [\n    //   \"string\"\n    // ],\n    // \"includedScopes\": [\n    //   {\n    //     \"filter\": \"EXCLUDING_CHILD_SCOPES\",\n    //     \"accountIdentifier\": \"string\",\n    //     \"orgIdentifier\": \"string\",\n    //     \"projectIdentifier\": \"string\"\n    //   }\n    // ],\n    // \"resourceFilter\": {\n    //   \"resources\": [\n    //     {\n    //       \"resourceType\": \"string\",\n    //       \"identifiers\": [\n    //         \"string\"\n    //       ],\n    //       \"attributeFilter\": {\n    //         \"attributeName\": \"string\",\n    //         \"attributeValues\": [\n    //           \"string\"\n    //         ]\n    //       }\n    //     }\n    //   ],\n    //   \"includeAllResources\": true\n    // }\n  }\n}",
+									"raw": "{\n  \"resourceGroup\": {\n    \"accountIdentifier\": \"{{Harness_Account_Identifier}}\",\n    // \"orgIdentifier\": \"string\",\n    // \"projectIdentifier\": \"string\",\n    \"identifier\": \"test_resource_group\",\n    \"name\": \"test resource group\"\n    // \"color\": \"string\",\n    // \"tags\": {\n    //   \"property1\": \"string\",\n    //   \"property2\": \"string\"\n    // },\n    // \"description\": \"string\",\n    // \"allowedScopeLevels\": [\n    //   \"string\"\n    // ],\n    // \"includedScopes\": [\n    //   {\n    //     \"filter\": \"EXCLUDING_CHILD_SCOPES\",\n    //     \"accountIdentifier\": \"string\",\n    //     \"orgIdentifier\": \"string\",\n    //     \"projectIdentifier\": \"string\"\n    //   }\n    // ],\n    // \"resourceFilter\": {\n    //   \"resources\": [\n    //     {\n    //       \"resourceType\": \"string\",\n    //       \"identifiers\": [\n    //         \"string\"\n    //       ],\n    //       \"attributeFilter\": {\n    //         \"attributeName\": \"string\",\n    //         \"attributeValues\": [\n    //           \"string\"\n    //         ]\n    //       }\n    //     }\n    //   ],\n    //   \"includeAllResources\": true\n    // }\n  }\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -2450,9 +5402,9 @@
 									}
 								},
 								"url": {
-									"raw": "{{Harness Resource Group Base URL}}/resourcegroup?accountIdentifier={{Harness Account Identifier}}",
+									"raw": "{{Harness_Resource_Group_Base_URL}}/resourcegroup?accountIdentifier={{Harness_Account_Identifier}}",
 									"host": [
-										"{{Harness Resource Group Base URL}}"
+										"{{Harness_Resource_Group_Base_URL}}"
 									],
 									"path": [
 										"resourcegroup"
@@ -2460,13 +5412,62 @@
 									"query": [
 										{
 											"key": "accountIdentifier",
-											"value": "{{Harness Account Identifier}}"
+											"value": "{{Harness_Account_Identifier}}"
 										}
 									]
 								},
-								"description": "Docs link: [https://apidocs.harness.io/tag/Harness-Resource-Group#operation/createResourceGroupV2](https://apidocs.harness.io/tag/Harness-Resource-Group#operation/createResourceGroupV2)"
+								"description": "**Harness API doc link - Create a Resource Group (Project scope):** [https://apidocs.harness.io/project-resource-groups/create-resource-group-project](https://apidocs.harness.io/project-resource-groups/delete-resource-group-project)\n\nSee also:\n\n**Harness API doc link - Create a Resource Group (Account scope):**\n\n[https://apidocs.harness.io/account-resource-groups/create-resource-group-acc](https://apidocs.harness.io/account-resource-groups/delete-resource-group-acc)\n\n**Harness API doc link - Create a Resource Group (Organization scope):**\n\n[https://apidocs.harness.io/organization-resource-groups/create-resource-group-org](https://apidocs.harness.io/organization-resource-groups/delete-resource-group-org)"
 							},
-							"response": []
+							"response": [
+								{
+									"name": "Successful Resource Group Creation (201 Created)",
+									"originalRequest": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "x-api-key",
+												"value": "{{Harness_API_Token}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n  \"resourceGroup\": {\n    \"accountIdentifier\": \"{{Harness_Account_Identifier}}\",\n    \"identifier\": \"test_resource_group\",\n    \"name\": \"test resource group\"\n  }\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{Harness_Resource_Group_Base_URL}}/resourcegroup?accountIdentifier={{Harness_Account_Identifier}}",
+											"host": [
+												"{{Harness_Resource_Group_Base_URL}}"
+											],
+											"path": [
+												"resourcegroup"
+											],
+											"query": [
+												{
+													"key": "accountIdentifier",
+													"value": "{{Harness Account Identifier}}"
+												}
+											]
+										}
+									},
+									"status": "Created",
+									"code": 201,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "x-api-key",
+											"value": "{{Harness_API_Token}}",
+											"description": ""
+										}
+									],
+									"cookie": [],
+									"body": "{\n  \"resourceGroup\": {\n    \"identifier\": \"test_resource_group\",\n    \"name\": \"test resource group\",\n    \"accountIdentifier\": \"{{Harness_Account_Identifier}}\"\n  },\n  \"created\": true,\n  \"message\": \"Resource group created successfully.\"\n}"
+								}
+							]
 						},
 						{
 							"name": "Update Resource Group",
@@ -2475,13 +5476,13 @@
 								"header": [
 									{
 										"key": "x-api-key",
-										"value": "{{Harness API Token}}",
+										"value": "{{Harness_API_Token}}",
 										"type": "text"
 									}
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n  \"resourceGroup\": {\n    \"accountIdentifier\": \"{{Harness Account Identifier}}\",\n    // \"orgIdentifier\": \"string\",\n    // \"projectIdentifier\": \"string\",\n    \"identifier\": \"test_resource_group\",\n    \"name\": \"test resource group updated\"\n    // \"color\": \"string\",\n    // \"tags\": {\n    //   \"property1\": \"string\",\n    //   \"property2\": \"string\"\n    // },\n    // \"description\": \"string\",\n    // \"allowedScopeLevels\": [\n    //   \"string\"\n    // ],\n    // \"includedScopes\": [\n    //   {\n    //     \"filter\": \"EXCLUDING_CHILD_SCOPES\",\n    //     \"accountIdentifier\": \"string\",\n    //     \"orgIdentifier\": \"string\",\n    //     \"projectIdentifier\": \"string\"\n    //   }\n    // ],\n    // \"resourceFilter\": {\n    //   \"resources\": [\n    //     {\n    //       \"resourceType\": \"string\",\n    //       \"identifiers\": [\n    //         \"string\"\n    //       ],\n    //       \"attributeFilter\": {\n    //         \"attributeName\": \"string\",\n    //         \"attributeValues\": [\n    //           \"string\"\n    //         ]\n    //       }\n    //     }\n    //   ],\n    //   \"includeAllResources\": true\n    // }\n  }\n}",
+									"raw": "{\n  \"resourceGroup\": {\n    \"accountIdentifier\": \"{{Harness_Account_Identifier}}\",\n    // \"orgIdentifier\": \"string\",\n    // \"projectIdentifier\": \"string\",\n    \"identifier\": \"test_resource_group\",\n    \"name\": \"test resource group updated\"\n    // \"color\": \"string\",\n    // \"tags\": {\n    //   \"property1\": \"string\",\n    //   \"property2\": \"string\"\n    // },\n    // \"description\": \"string\",\n    // \"allowedScopeLevels\": [\n    //   \"string\"\n    // ],\n    // \"includedScopes\": [\n    //   {\n    //     \"filter\": \"EXCLUDING_CHILD_SCOPES\",\n    //     \"accountIdentifier\": \"string\",\n    //     \"orgIdentifier\": \"string\",\n    //     \"projectIdentifier\": \"string\"\n    //   }\n    // ],\n    // \"resourceFilter\": {\n    //   \"resources\": [\n    //     {\n    //       \"resourceType\": \"string\",\n    //       \"identifiers\": [\n    //         \"string\"\n    //       ],\n    //       \"attributeFilter\": {\n    //         \"attributeName\": \"string\",\n    //         \"attributeValues\": [\n    //           \"string\"\n    //         ]\n    //       }\n    //     }\n    //   ],\n    //   \"includeAllResources\": true\n    // }\n  }\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -2489,24 +5490,78 @@
 									}
 								},
 								"url": {
-									"raw": "{{Harness Resource Group Base URL}}/resourcegroup/{{Harness Resource Group Identifier}}?accountIdentifier={{Harness Account Identifier}}",
+									"raw": "{{Harness_Resource_Group_Base_URL}}/resourcegroup/{{Harness_Resource_Group_Identifier}}?accountIdentifier={{Harness_Account_Identifier}}",
 									"host": [
-										"{{Harness Resource Group Base URL}}"
+										"{{Harness_Resource_Group_Base_URL}}"
 									],
 									"path": [
 										"resourcegroup",
-										"{{Harness Resource Group Identifier}}"
+										"{{Harness_Resource_Group_Identifier}}"
 									],
 									"query": [
 										{
 											"key": "accountIdentifier",
-											"value": "{{Harness Account Identifier}}"
+											"value": "{{Harness_Account_Identifier}}"
 										}
 									]
 								},
-								"description": "Docs link: [https://apidocs.harness.io/tag/Harness-Resource-Group#operation/updateResourceGroupV2](https://apidocs.harness.io/tag/Harness-Resource-Group#operation/updateResourceGroupV2)"
+								"description": "**Harness API doc link - Update a Resource Group (Project scope):** [https://apidocs.harness.io/project-resource-groups/update-resource-group-project](https://apidocs.harness.io/project-resource-groups/update-resource-group-project)\n\nSee also:\n\n**Harness API doc link - Update a Resource Group (Account scope):**\n\n[https://apidocs.harness.io/account-resource-groups/update-resource-group-acc](https://apidocs.harness.io/account-resource-groups/update-resource-group-acc)\n\n**Harness API doc link - Update a Resource Group (Organization scope):**\n\n[https://apidocs.harness.io/organization-resource-groups/update-resource-group-org](https://apidocs.harness.io/organization-resource-groups/update-resource-group-org)"
 							},
-							"response": []
+							"response": [
+								{
+									"name": "Successful Update Resource Group",
+									"originalRequest": {
+										"method": "PUT",
+										"header": [
+											{
+												"key": "x-api-key",
+												"value": "{{Harness_API_Token}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n  \"resourceGroup\": {\n    \"accountIdentifier\": \"{{Harness_Account_Identifier}}\",\n    \"identifier\": \"test_resource_group\",\n    \"name\": \"test resource group updated\"\n  }\n}",
+											"options": {
+												"raw": "json"
+											}
+										},
+										"url": {
+											"raw": "{{Harness_Resource_Group_Base_URL}}/resourcegroup/{{Harness_Resource_Group_Identifier}}?accountIdentifier={{Harness_Account_Identifier}}",
+											"host": [
+												"{{Harness_Resource_Group_Base_URL}}"
+											],
+											"path": [
+												"resourcegroup",
+												"{{Harness_Resource_Group_Identifier}}"
+											],
+											"query": [
+												{
+													"key": "accountIdentifier",
+													"value": "{{Harness Account Identifier}}"
+												}
+											],
+											"variable": [
+												{
+													"key": "Harness Resource Group Identifier",
+													"value": "test_resource_group"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "x-api-key",
+											"value": "{{Harness_API_Token}}",
+											"description": ""
+										}
+									],
+									"cookie": [],
+									"body": "{\n  \"resourceGroup\": {\n    \"accountIdentifier\": \"{{Harness_Account_Identifier}}\",\n    \"identifier\": \"test_resource_group\",\n    \"name\": \"test resource group updated\",\n    \"color\": \"#FFFFFF\",\n    \"tags\": {},\n    \"description\": \"Updated resource group for demonstration.\",\n    \"allowedScopeLevels\": [\"account\"],\n    \"includedScopes\": [\n      {\n        \"filter\": \"EXCLUDING_CHILD_SCOPES\",\n        \"accountIdentifier\": \"{{Harness_Account_Identifier}}\"\n      }\n    ],\n    \"resourceFilter\": {\n      \"resources\": [],\n      \"includeAllResources\": true\n    }\n  },\n  \"created\": false,\n  \"updated\": true\n}"
+								}
+							]
 						},
 						{
 							"name": "List Resource Groups",
@@ -2518,7 +5573,7 @@
 								"header": [
 									{
 										"key": "x-api-key",
-										"value": "{{Harness API Token}}",
+										"value": "{{Harness_API_Token}}",
 										"type": "text"
 									}
 								],
@@ -2532,9 +5587,9 @@
 									}
 								},
 								"url": {
-									"raw": "{{Harness Resource Group Base URL}}/resourcegroup?accountIdentifier={{Harness Account Identifier}}",
+									"raw": "{{Harness_Resource_Group_Base_URL}}/resourcegroup?accountIdentifier={{Harness_Account_Identifier}}",
 									"host": [
-										"{{Harness Resource Group Base URL}}"
+										"{{Harness_Resource_Group_Base_URL}}"
 									],
 									"path": [
 										"resourcegroup"
@@ -2542,13 +5597,62 @@
 									"query": [
 										{
 											"key": "accountIdentifier",
-											"value": "{{Harness Account Identifier}}"
+											"value": "{{Harness_Account_Identifier}}"
 										}
 									]
 								},
-								"description": "Docs link: [https://apidocs.harness.io/tag/Harness-Resource-Group#operation/getResourceGroupListV2](https://apidocs.harness.io/tag/Harness-Resource-Group#operation/getResourceGroupListV2)"
+								"description": "**Harness API doc link - List Resource Groups (Project scope):** [https://apidocs.harness.io/project-resource-groups/list-resource-groups-project](https://apidocs.harness.io/project-resource-groups/list-resource-groups-project)\n\nSee also:\n\n**Harness API doc link - List Resource Groups (Account scope):**\n\n[https://apidocs.harness.io/account-resource-groups/list-resource-groups-acc](https://apidocs.harness.io/account-resource-groups/list-resource-groups-acc)\n\n**Harness API doc link - List Resource Groups (Organization scope):** [https://apidocs.harness.io/organization-resource-groups/list-resource-groups-org](https://apidocs.harness.io/organization-resource-groups/list-resource-groups-org)"
 							},
-							"response": []
+							"response": [
+								{
+									"name": "200 OK - List Resource Groups Example",
+									"originalRequest": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "x-api-key",
+												"value": "{{Harness_API_Token}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{Harness_Resource_Group_Base_URL}}/resourcegroup?accountIdentifier={{Harness_Account_Identifier}}",
+											"host": [
+												"{{Harness_Resource_Group_Base_URL}}"
+											],
+											"path": [
+												"resourcegroup"
+											],
+											"query": [
+												{
+													"key": "accountIdentifier",
+													"value": "{{Harness Account Identifier}}"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "x-api-key",
+											"value": "{{Harness_API_Token}}",
+											"description": ""
+										}
+									],
+									"cookie": [],
+									"body": "{\n  \"resourceGroups\": [\n    {\n      \"identifier\": \"_fme_all_resources\",\n      \"name\": \"All FME Resources\",\n      \"resourceSelectors\": [\n        {\n          \"resourceType\": \"PROJECT\",\n          \"identifiers\": [\"project1\", \"project2\"]\n        }\n      ],\n      \"description\": \"Resource group for all FME project resources.\",\n      \"createdAt\": \"2024-06-01T12:00:00Z\",\n      \"updatedAt\": \"2024-06-10T15:30:00Z\"\n    },\n    {\n      \"identifier\": \"custom_group_1\",\n      \"name\": \"Custom Resource Group\",\n      \"resourceSelectors\": [\n        {\n          \"resourceType\": \"FEATURE\",\n          \"identifiers\": [\"featureA\", \"featureB\"]\n        }\n      ],\n      \"description\": \"Custom group for selected features.\",\n      \"createdAt\": \"2024-06-05T09:00:00Z\",\n      \"updatedAt\": \"2024-06-10T15:30:00Z\"\n    }\n  ],\n  \"page\": 0,\n  \"limit\": 50,\n  \"total\": 2\n}"
+								}
+							]
 						},
 						{
 							"name": "Delete Resource Group",
@@ -2557,7 +5661,7 @@
 								"header": [
 									{
 										"key": "x-api-key",
-										"value": "{{Harness API Token}}",
+										"value": "{{Harness_API_Token}}",
 										"type": "text"
 									}
 								],
@@ -2571,24 +5675,88 @@
 									}
 								},
 								"url": {
-									"raw": "{{Harness Resource Group Base URL}}/resourcegroup/{{Harness Resource Group Identifier}}?accountIdentifier={{Harness Account Identifier}}",
+									"raw": "{{Harness_Resource_Group_Base_URL}}/resourcegroup/{{Harness_Resource_Group_Identifier}}?accountIdentifier={{Harness_Account_Identifier}}",
 									"host": [
-										"{{Harness Resource Group Base URL}}"
+										"{{Harness_Resource_Group_Base_URL}}"
 									],
 									"path": [
 										"resourcegroup",
-										"{{Harness Resource Group Identifier}}"
+										"{{Harness_Resource_Group_Identifier}}"
 									],
 									"query": [
 										{
 											"key": "accountIdentifier",
-											"value": "{{Harness Account Identifier}}"
+											"value": "{{Harness_Account_Identifier}}"
 										}
 									]
 								},
-								"description": "Docs link: [https://apidocs.harness.io/tag/Harness-Resource-Group#operation/deleteResourceGroupV2](https://apidocs.harness.io/tag/Harness-Resource-Group#operation/deleteResourceGroupV2)"
+								"description": "**Harness API doc link - Delete a Resource Group (Project scope):** [https://apidocs.harness.io/project-resource-groups/delete-resource-group-project](https://apidocs.harness.io/project-resource-groups/delete-resource-group-project)\n\nSee also:\n\n**Harness API doc link - Delete a Resource Group (Account scope):**\n\n[https://apidocs.harness.io/account-resource-groups/delete-resource-group-acc](https://apidocs.harness.io/account-resource-groups/delete-resource-group-acc)\n\n**Harness API doc link - Delete a Resource Group (Organization scope):**\n\n[https://apidocs.harness.io/organization-resource-groups/delete-resource-group-org](https://apidocs.harness.io/organization-resource-groups/delete-resource-group-org)"
 							},
-							"response": []
+							"response": [
+								{
+									"name": "Successful Resource Group Deletion (204 No Content)",
+									"originalRequest": {
+										"method": "DELETE",
+										"header": [
+											{
+												"key": "x-api-key",
+												"value": "{{Harness_API_Token}}",
+												"description": "Harness API authentication token"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{Harness_Resource_Group_Base_URL}}/resourcegroup/{{Harness_Resource_Group_Identifier}}?accountIdentifier={{Harness_Account_Identifier}}",
+											"host": [
+												"{{Harness_Resource_Group_Base_URL}}"
+											],
+											"path": [
+												"resourcegroup",
+												"{{Harness_Resource_Group_Identifier}}"
+											],
+											"query": [
+												{
+													"key": "accountIdentifier",
+													"value": "{{Harness Account Identifier}}",
+													"description": "Harness_Account_Identifier"
+												}
+											],
+											"variable": [
+												{
+													"key": "Harness Resource Group Identifier",
+													"value": "<resource_group_id>",
+													"description": "The identifier of the Harness resource group to delete"
+												},
+												{
+													"key": "Harness Account Identifier",
+													"value": "<account_id>",
+													"description": "The Harness_Account_Identifier"
+												}
+											]
+										}
+									},
+									"status": "No Content",
+									"code": 204,
+									"_postman_previewlanguage": "text",
+									"header": [
+										{
+											"key": "x-api-key",
+											"value": "{{Harness_API_Token}}",
+											"description": "Harness API authentication token"
+										}
+									],
+									"cookie": [],
+									"body": "Resource group deleted successfully. No content returned."
+								}
+							]
 						}
 					],
 					"description": "The `/roleassignments`, `/role`, and `/resourcegroup` endpoints here replace the Split `/restrictions` endpoint after your migration to Harness.\n\nThe examples in this folder demonstrate the power of Harness' RBAC structure for managing any sort of resource, not just a project. Please see the overview in the \"Restrictions\" folder (parent to this folder) for more context before you dive in here.",
@@ -2597,7 +5765,7 @@
 						"apikey": [
 							{
 								"key": "value",
-								"value": "{{Harness API Token}}",
+								"value": "{{Harness_API_Token}}",
 								"type": "string"
 							},
 							{
@@ -2650,6 +5818,7 @@
 			"script": {
 				"type": "text/javascript",
 				"packages": {},
+				"requests": {},
 				"exec": [
 					""
 				]
@@ -2660,6 +5829,7 @@
 			"script": {
 				"type": "text/javascript",
 				"packages": {},
+				"requests": {},
 				"exec": [
 					""
 				]
@@ -2668,119 +5838,119 @@
 	],
 	"variable": [
 		{
-			"key": "Split API Base URL",
+			"key": "Split_API_Base_URL",
 			"value": "https://api.split.io/internal/api/v2"
 		},
 		{
-			"key": "Harness Account Identifier",
+			"key": "Harness_Account_Identifier",
 			"value": ""
 		},
 		{
-			"key": "Harness API Base URL",
+			"key": "Harness_API_Base_URL",
 			"value": "https://app.harness.io/ng/api"
 		},
 		{
-			"key": "Harness API Token",
+			"key": "Harness_API_Token",
 			"value": ""
 		},
 		{
-			"key": "Harness User Identifier",
+			"key": "Harness_User_Identifier",
 			"value": ""
 		},
 		{
-			"key": "Split API Token",
+			"key": "Split_API_Token",
 			"value": ""
 		},
 		{
-			"key": "Split User Identifier",
+			"key": "Split_User_Identifier",
 			"value": ""
 		},
 		{
-			"key": "Split Pending User Identifier",
+			"key": "Split_Pending_User_Identifier",
 			"value": ""
 		},
 		{
-			"key": "Split Group Identifier",
+			"key": "Split_Group_Identifier",
 			"value": ""
 		},
 		{
-			"key": "Harness Group Identifier",
+			"key": "Harness_Group_Identifier",
 			"value": ""
 		},
 		{
-			"key": "Split Workspace Identifier",
+			"key": "Split_Workspace_Identifier",
 			"value": ""
 		},
 		{
-			"key": "Harness Organization Identifier",
+			"key": "Harness_Organization_Identifier",
 			"value": ""
 		},
 		{
-			"key": "Harness Project Identifier",
+			"key": "Harness_Project_Identifier",
 			"value": ""
 		},
 		{
-			"key": "Split Environment Identifier",
+			"key": "Split_Environment_Identifier",
 			"value": ""
 		},
 		{
-			"key": "Split Admin API Key Identifier",
+			"key": "Split_Admin_API_Key_Identifier",
 			"value": ""
 		},
 		{
-			"key": "Harness Auth Base URL",
+			"key": "Harness_Auth_Base_URL",
 			"value": "https://app.harness.io/authz/api"
 		},
 		{
-			"key": "Harness Resource Group Base URL",
+			"key": "Harness_Resource_Group_Base_URL",
 			"value": "https://app.harness.io/resourcegroup/api/v2"
 		},
 		{
-			"key": "Harness API Key Identifier",
+			"key": "Harness_API_Key_Identifier",
 			"value": ""
 		},
 		{
-			"key": "Harness Token Identifier",
+			"key": "Harness_Token_Identifier",
 			"value": ""
 		},
 		{
-			"key": "Harness Parent Identifier",
+			"key": "Harness_Parent_Identifier",
 			"value": ""
 		},
 		{
-			"key": "Harness Rotate Timestamp",
+			"key": "Harness_Rotate_Timestamp",
 			"value": ""
 		},
 		{
-			"key": "Harness API Key Type",
+			"key": "Harness_API_Key_Type",
 			"value": "SERVICE_ACCOUNT"
 		},
 		{
-			"key": "Harness Service Account Identifier",
+			"key": "Harness_Service_Account_Identifier",
 			"value": ""
 		},
 		{
-			"key": "Harness Role Assignment Identifier",
+			"key": "Harness_Role_Assignment_Identifier",
 			"value": ""
 		},
 		{
-			"key": "Split Resource Type",
+			"key": "Split_Resource_Type",
 			"value": "workspace"
 		},
 		{
-			"key": "Split Resource Identifier",
+			"key": "Split_Resource_Identifier",
 			"value": ""
 		},
 		{
-			"key": "Harness Role Identifier",
+			"key": "Harness_Role_Identifier",
 			"value": ""
 		},
 		{
-			"key": "Harness Resource Group Identifier",
+			"key": "Harness_Resource_Group_Identifier",
 			"value": ""
 		},
 		{
-			"key": "Harness Invite Identifier",
+			"key": "Harness_Invite_Identifier",
 			"value": ""
 		}
 	]


### PR DESCRIPTION
Changes:

1. Variables updated to replace the space between words (` `) with an underscore (`_`) in order to improve compatibility with 3rd party tools. NOTE: Environment files (if you have made them) will need to be updated as well.  Simply replace ` ` with `_` in variable names.
2. We have added descriptions to many endpoints. This work is ongoing, and more descriptions will be added soon.
3. Changed path parameter `:userId` to collection variable `{{Split_Pending_User_Identifier}}` in Users > Split (BEFORE) > Delete a Pending User entry.

Note: we recently placed this collection inside a team account. That changed the URL to the collection on the Postman Network.  Here is the updated URL: https://www.postman.com/harness-fme-enablement/harness-fme/collection/hyphfpd/before-and-after-apis-for-split-admins

Related documentation on Harness Developer Hub is here: https://developer.harness.io/docs/feature-management-experimentation/split-to-harness/api-for-split-admins